### PR TITLE
feat: Phase 1 - Core Project Scaffolding & Basic Server

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,10 @@
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=native"]
+
+[build]
+rustflags = [
+    "-W", "clippy::all",
+    "-W", "clippy::pedantic",
+    "-A", "clippy::module_name_repetitions",
+    "-A", "clippy::must_use_candidate",
+]

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+# Rust build artifacts
+/target/
+Cargo.lock
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Environment
+.env
+.env.local
+
+# Data
+/data/
+*.onnx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,64 @@
+[package]
+name = "insight-sidecar"
+version = "0.1.0"
+edition = "2021"
+description = "ML inference sidecar for Music Assistant - provides audio/text embeddings using CLAP models"
+license = "Apache-2.0"
+repository = "https://github.com/ztripez/music-assistant-insights"
+rust-version = "1.75"
+
+[features]
+default = []
+cuda = ["inference", "ort/cuda"]
+inference = ["dep:ort"]
+storage = ["dep:qdrant-client"]
+audio = ["dep:symphonia"]
+full = ["inference", "storage", "audio"]
+integration = []
+
+[dependencies]
+# HTTP/WebSocket server
+axum = { version = "0.7", features = ["ws", "macros"] }
+tower = "0.4"
+tower-http = { version = "0.5", features = ["cors", "trace"] }
+
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+rmp-serde = "1"
+
+# Configuration
+config = "0.14"
+
+# Error handling
+thiserror = "1"
+anyhow = "1"
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+
+# ML inference (Phase 2 - optional)
+ort = { version = "2.0.0-rc.10", default-features = false, features = ["download-binaries"], optional = true }
+
+# Vector storage (Phase 2 - optional)
+qdrant-client = { version = "1", optional = true }
+
+# Audio processing (Phase 2 - optional)
+symphonia = { version = "0.5", features = ["all"], optional = true }
+
+# Utilities
+uuid = { version = "1", features = ["v4", "serde"] }
+bytes = "1"
+
+[dev-dependencies]
+tokio-test = "0.4"
+axum-test = "15"
+
+[profile.release]
+lto = true
+codegen-units = 1
+strip = true

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+edition = "2021"
+max_width = 100
+use_small_heuristics = "Default"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,182 @@
+use config::{Config, ConfigError, Environment};
+use serde::Deserialize;
+use std::net::SocketAddr;
+
+/// Application configuration loaded from environment variables.
+///
+/// All settings can be configured via environment variables with the `INSIGHT_` prefix.
+/// For example: `INSIGHT_PORT=8096`, `INSIGHT_ENABLE_CUDA=true`
+#[derive(Debug, Clone, Deserialize)]
+pub struct AppConfig {
+    /// Model configuration
+    #[serde(default)]
+    pub model: ModelConfig,
+
+    /// Audio processing configuration
+    #[serde(default)]
+    pub audio: AudioConfig,
+
+    /// Storage configuration
+    #[serde(default)]
+    pub storage: StorageConfig,
+
+    /// Server configuration
+    #[serde(default)]
+    pub server: ServerConfig,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ModelConfig {
+    /// CLAP model to use (Hugging Face model ID)
+    #[serde(default = "default_model")]
+    pub name: String,
+
+    /// Enable CUDA acceleration
+    #[serde(default)]
+    pub enable_cuda: bool,
+}
+
+impl Default for ModelConfig {
+    fn default() -> Self {
+        Self {
+            name: default_model(),
+            enable_cuda: false,
+        }
+    }
+}
+
+fn default_model() -> String {
+    "Xenova/clap-htsat-unfused".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct AudioConfig {
+    /// Window size in seconds for audio processing
+    #[serde(default = "default_window_size")]
+    pub window_size_s: f32,
+
+    /// Hop size in seconds between windows
+    #[serde(default = "default_hop_size")]
+    pub hop_size_s: f32,
+}
+
+impl Default for AudioConfig {
+    fn default() -> Self {
+        Self {
+            window_size_s: default_window_size(),
+            hop_size_s: default_hop_size(),
+        }
+    }
+}
+
+fn default_window_size() -> f32 {
+    10.0
+}
+
+fn default_hop_size() -> f32 {
+    10.0
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StorageConfig {
+    /// Path to Qdrant storage directory
+    #[serde(default = "default_storage_path")]
+    pub path: String,
+}
+
+impl Default for StorageConfig {
+    fn default() -> Self {
+        Self {
+            path: default_storage_path(),
+        }
+    }
+}
+
+fn default_storage_path() -> String {
+    "./data/qdrant".to_string()
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ServerConfig {
+    /// Host to bind to
+    #[serde(default = "default_host")]
+    pub host: String,
+
+    /// Port to listen on
+    #[serde(default = "default_port")]
+    pub port: u16,
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: default_host(),
+            port: default_port(),
+        }
+    }
+}
+
+fn default_host() -> String {
+    "0.0.0.0".to_string()
+}
+
+fn default_port() -> u16 {
+    8096
+}
+
+impl ServerConfig {
+    /// Returns the socket address for binding the server
+    pub fn socket_addr(&self) -> SocketAddr {
+        format!("{}:{}", self.host, self.port)
+            .parse()
+            .expect("Invalid socket address")
+    }
+}
+
+impl AppConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// Environment variables should be prefixed with `INSIGHT_` and use
+    /// double underscores for nested values:
+    /// - `INSIGHT_MODEL__NAME` -> model.name
+    /// - `INSIGHT_MODEL__ENABLE_CUDA` -> model.enable_cuda
+    /// - `INSIGHT_SERVER__PORT` -> server.port
+    pub fn load() -> Result<Self, ConfigError> {
+        let config = Config::builder()
+            .add_source(
+                Environment::with_prefix("INSIGHT")
+                    .separator("__")
+                    .try_parsing(true),
+            )
+            .build()?;
+
+        config.try_deserialize()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_config() {
+        let config = AppConfig {
+            model: ModelConfig::default(),
+            audio: AudioConfig::default(),
+            storage: StorageConfig::default(),
+            server: ServerConfig::default(),
+        };
+
+        assert_eq!(config.model.name, "Xenova/clap-htsat-unfused");
+        assert!(!config.model.enable_cuda);
+        assert_eq!(config.audio.window_size_s, 10.0);
+        assert_eq!(config.server.port, 8096);
+    }
+
+    #[test]
+    fn test_socket_addr() {
+        let server = ServerConfig::default();
+        let addr = server.socket_addr();
+        assert_eq!(addr.port(), 8096);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,91 @@
+use axum::{
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use thiserror::Error;
+
+/// Application-level errors
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("Configuration error: {0}")]
+    Config(#[from] config::ConfigError),
+
+    #[error("Internal server error: {0}")]
+    Internal(String),
+
+    #[error("Bad request: {0}")]
+    BadRequest(String),
+
+    #[error("Not found: {0}")]
+    NotFound(String),
+
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+}
+
+impl AppError {
+    /// Returns the appropriate HTTP status code for this error
+    pub fn status_code(&self) -> StatusCode {
+        match self {
+            Self::Config(_) | Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+            Self::BadRequest(_) | Self::Serialization(_) => StatusCode::BAD_REQUEST,
+            Self::NotFound(_) => StatusCode::NOT_FOUND,
+        }
+    }
+
+    /// Returns a machine-readable error code
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Config(_) => "CONFIG_ERROR",
+            Self::Internal(_) => "INTERNAL_ERROR",
+            Self::BadRequest(_) => "BAD_REQUEST",
+            Self::NotFound(_) => "NOT_FOUND",
+            Self::Serialization(_) => "SERIALIZATION_ERROR",
+        }
+    }
+}
+
+/// Error response body structure
+#[derive(Debug, Serialize)]
+pub struct ErrorResponse {
+    pub error: ErrorDetail,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ErrorDetail {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let body = ErrorResponse {
+            error: ErrorDetail {
+                code: self.code(),
+                message: self.to_string(),
+            },
+        };
+
+        // Try to serialize as msgpack, fall back to JSON
+        match rmp_serde::to_vec(&body) {
+            Ok(bytes) => (
+                status,
+                [("content-type", "application/msgpack")],
+                bytes,
+            )
+                .into_response(),
+            Err(_) => {
+                // Fallback to JSON if msgpack fails
+                let json = serde_json::to_string(&body).unwrap_or_else(|_| {
+                    r#"{"error":{"code":"SERIALIZATION_ERROR","message":"Failed to serialize error"}}"#.to_string()
+                });
+                (status, [("content-type", "application/json")], json).into_response()
+            }
+        }
+    }
+}
+
+/// Result type alias for handlers
+pub type Result<T> = std::result::Result<T, AppError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,13 @@
+//! Music Assistant Insight Sidecar
+//!
+//! A lightweight, high-performance inference sidecar for Music Assistant that
+//! provides audio and text embeddings using CLAP (Contrastive Language-Audio
+//! Pretraining) models.
+
+pub mod config;
+pub mod error;
+pub mod server;
+pub mod types;
+
+pub use config::AppConfig;
+pub use error::{AppError, Result};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,96 @@
+//! Music Assistant Insight Sidecar - Entry Point
+
+use anyhow::Context;
+use tokio::signal;
+use tracing::{info, warn};
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+use insight_sidecar::{config::AppConfig, server};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    // Initialize logging
+    init_logging();
+
+    info!("Starting Music Assistant Insight Sidecar");
+
+    // Load configuration
+    let config = AppConfig::load().unwrap_or_else(|e| {
+        warn!("Failed to load config from environment: {e}, using defaults");
+        AppConfig {
+            model: Default::default(),
+            audio: Default::default(),
+            storage: Default::default(),
+            server: Default::default(),
+        }
+    });
+
+    info!(
+        model = %config.model.name,
+        cuda = config.model.enable_cuda,
+        "Configuration loaded"
+    );
+
+    // Create app state
+    let state = server::AppState::new(config.clone());
+
+    // Create router
+    let app = server::create_router(state);
+
+    // Bind to socket
+    let addr = config.server.socket_addr();
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .context("Failed to bind to address")?;
+
+    info!(%addr, "Server listening");
+
+    // Run server with graceful shutdown
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await
+        .context("Server error")?;
+
+    info!("Server shutdown complete");
+    Ok(())
+}
+
+/// Initialize the tracing subscriber for logging
+fn init_logging() {
+    tracing_subscriber::registry()
+        .with(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "insight_sidecar=info,tower_http=debug".into()),
+        )
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+}
+
+/// Graceful shutdown signal handler
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("Failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => {
+            info!("Received Ctrl+C, starting graceful shutdown");
+        }
+        () = terminate => {
+            info!("Received SIGTERM, starting graceful shutdown");
+        }
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,0 +1,35 @@
+//! HTTP server setup and routing.
+
+mod routes;
+
+use axum::{routing::get, Router};
+use std::sync::Arc;
+use tower_http::trace::TraceLayer;
+
+use crate::config::AppConfig;
+
+/// Shared application state passed to all handlers
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<AppConfig>,
+}
+
+impl AppState {
+    pub fn new(config: AppConfig) -> Self {
+        Self {
+            config: Arc::new(config),
+        }
+    }
+}
+
+/// Creates the application router with all routes configured
+pub fn create_router(state: AppState) -> Router {
+    let api_routes = Router::new()
+        .route("/health", get(routes::health))
+        .route("/config", get(routes::config));
+
+    Router::new()
+        .nest("/api/v1", api_routes)
+        .layer(TraceLayer::new_for_http())
+        .with_state(state)
+}

--- a/src/server/routes.rs
+++ b/src/server/routes.rs
@@ -1,0 +1,68 @@
+//! HTTP route handlers.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+
+use crate::types::{
+    AudioInfo, ConfigResponse, HealthResponse, HealthStatus, ModelInfo, ServerInfo,
+};
+
+use super::AppState;
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// MessagePack response wrapper
+pub struct MsgPack<T>(pub T);
+
+impl<T: serde::Serialize> IntoResponse for MsgPack<T> {
+    fn into_response(self) -> Response {
+        match rmp_serde::to_vec(&self.0) {
+            Ok(bytes) => (
+                StatusCode::OK,
+                [("content-type", "application/msgpack")],
+                bytes,
+            )
+                .into_response(),
+            Err(e) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to serialize response: {e}"),
+            )
+                .into_response(),
+        }
+    }
+}
+
+/// Health check endpoint
+///
+/// GET /api/v1/health
+pub async fn health() -> MsgPack<HealthResponse> {
+    MsgPack(HealthResponse {
+        status: HealthStatus::Healthy,
+        version: VERSION.to_string(),
+    })
+}
+
+/// Configuration endpoint
+///
+/// GET /api/v1/config
+pub async fn config(State(state): State<AppState>) -> MsgPack<ConfigResponse> {
+    let config = &state.config;
+
+    MsgPack(ConfigResponse {
+        model: ModelInfo {
+            name: config.model.name.clone(),
+            cuda_enabled: config.model.enable_cuda,
+        },
+        audio: AudioInfo {
+            window_size_s: config.audio.window_size_s,
+            hop_size_s: config.audio.hop_size_s,
+        },
+        server: ServerInfo {
+            host: config.server.host.clone(),
+            port: config.server.port,
+        },
+    })
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -1,0 +1,47 @@
+//! Shared types for the insight sidecar API.
+//!
+//! These types are used across the application for request/response handling
+//! and internal data representation.
+
+use serde::{Deserialize, Serialize};
+
+/// Health check response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthResponse {
+    pub status: HealthStatus,
+    pub version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum HealthStatus {
+    Healthy,
+    Degraded,
+    Unhealthy,
+}
+
+/// Configuration response (subset of config safe to expose)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConfigResponse {
+    pub model: ModelInfo,
+    pub audio: AudioInfo,
+    pub server: ServerInfo,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelInfo {
+    pub name: String,
+    pub cuda_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioInfo {
+    pub window_size_s: f32,
+    pub hop_size_s: f32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerInfo {
+    pub host: String,
+    pub port: u16,
+}


### PR DESCRIPTION
## Summary

- Initialize Rust project with core dependencies (axum, tokio, serde, tracing)
- Implement configuration system with `INSIGHT_*` environment variable support
- Create error types with axum `IntoResponse` for msgpack error responses
- Set up basic axum server with health and config endpoints
- Add graceful shutdown handling with SIGTERM/SIGINT support
- Configure rustfmt and clippy for code quality

## What's Included

| Component | Description |
|-----------|-------------|
| `Cargo.toml` | Project manifest with optional feature flags for ML/storage/audio |
| `src/config.rs` | Configuration loading from environment variables |
| `src/error.rs` | Application error types with HTTP status mapping |
| `src/server/` | Axum router with `/api/v1/health` and `/api/v1/config` endpoints |
| `src/types/` | Shared request/response types |
| `src/main.rs` | Entry point with logging and graceful shutdown |

## Endpoints

- `GET /api/v1/health` - Returns health status and version (msgpack)
- `GET /api/v1/config` - Returns current configuration (msgpack)

## Test plan

- [x] `cargo build` succeeds
- [x] `cargo test` passes (2 config tests)
- [x] `cargo clippy` passes with no warnings
- [ ] Manual test: `cargo run` starts server on port 8096
- [ ] Manual test: Health endpoint responds correctly

Closes #1
