### PR TITLE
feat: Phase 3 Vector Storage with Qdrant integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ qdrant-client = { version = "1", optional = true }
 symphonia = { version = "0.5", features = ["all"], optional = true }
 
 # Utilities
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 bytes = "1"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,9 @@ config = "0.14"
 thiserror = "1"
 anyhow = "1"
 
+# Async trait support
+async-trait = "0.1"
+
 # Logging
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,21 +79,35 @@ fn default_hop_size() -> f32 {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct StorageConfig {
-    /// Path to Qdrant storage directory
-    #[serde(default = "default_storage_path")]
-    pub path: String,
+    /// Qdrant server URL
+    #[serde(default = "default_qdrant_url")]
+    pub url: String,
+
+    /// Prefix for collection names (useful for multi-tenant setups)
+    #[serde(default)]
+    pub collection_prefix: Option<String>,
+
+    /// Enable storage (set to false to run without vector storage)
+    #[serde(default = "default_storage_enabled")]
+    pub enabled: bool,
 }
 
 impl Default for StorageConfig {
     fn default() -> Self {
         Self {
-            path: default_storage_path(),
+            url: default_qdrant_url(),
+            collection_prefix: None,
+            enabled: default_storage_enabled(),
         }
     }
 }
 
-fn default_storage_path() -> String {
-    "./data/qdrant".to_string()
+fn default_qdrant_url() -> String {
+    "http://localhost:6334".to_string()
+}
+
+fn default_storage_enabled() -> bool {
+    true
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod error;
 #[cfg(feature = "inference")]
 pub mod inference;
 pub mod server;
+pub mod storage;
 pub mod types;
 
 pub use config::AppConfig;

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::Context;
 use tokio::signal;
-#[cfg(feature = "inference")]
+#[cfg(any(feature = "inference", feature = "storage"))]
 use tracing::error;
 use tracing::{info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
@@ -30,10 +30,11 @@ async fn main() -> anyhow::Result<()> {
     info!(
         model = %config.model.name,
         cuda = config.model.enable_cuda,
+        storage_url = %config.storage.url,
         "Configuration loaded"
     );
 
-    // Create app state (with or without model)
+    // Create app state (with optional model and storage)
     let state = create_app_state(config.clone()).await;
 
     // Create router
@@ -57,19 +58,100 @@ async fn main() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Create application state, loading the ML model if inference feature is enabled
-#[cfg(feature = "inference")]
+/// Create application state, loading the ML model and storage if features are enabled
+#[cfg(all(feature = "inference", feature = "storage"))]
+async fn create_app_state(config: AppConfig) -> server::AppState {
+    use insight_sidecar::inference::{download_model, ClapModel};
+    use insight_sidecar::storage::{QdrantStorage, VectorStorage};
+
+    // Load model first
+    let model = load_model(&config).await;
+
+    // Then connect to storage
+    let storage = connect_storage(&config).await;
+
+    match (model, storage) {
+        (Some(m), Some(s)) => server::AppState::with_model_and_storage(config, m, s),
+        (Some(m), None) => server::AppState::with_model(config, m),
+        (None, Some(s)) => server::AppState::with_storage(config, s),
+        (None, None) => server::AppState::new(config),
+    }
+}
+
+#[cfg(all(feature = "inference", feature = "storage"))]
+async fn load_model(config: &AppConfig) -> Option<insight_sidecar::inference::ClapModel> {
+    use insight_sidecar::inference::{download_model, ClapModel};
+
+    info!(model = %config.model.name, "Downloading/loading CLAP model...");
+
+    match download_model(&config.model.name, None).await {
+        Ok(paths) => {
+            info!(?paths, "Model files ready, loading into ONNX Runtime...");
+            let use_cuda = config.model.enable_cuda;
+            match tokio::task::spawn_blocking(move || ClapModel::load(&paths, use_cuda)).await {
+                Ok(Ok(model)) => {
+                    info!(device = %model.device(), "CLAP model loaded successfully");
+                    Some(model)
+                }
+                Ok(Err(e)) => {
+                    error!("Failed to load model: {e}");
+                    warn!("Starting without ML inference capability");
+                    None
+                }
+                Err(e) => {
+                    error!("Model loading task panicked: {e}");
+                    warn!("Starting without ML inference capability");
+                    None
+                }
+            }
+        }
+        Err(e) => {
+            error!("Failed to download model: {e}");
+            warn!("Starting without ML inference capability");
+            None
+        }
+    }
+}
+
+#[cfg(all(feature = "inference", feature = "storage"))]
+async fn connect_storage(config: &AppConfig) -> Option<insight_sidecar::storage::QdrantStorage> {
+    use insight_sidecar::storage::{QdrantStorage, VectorStorage};
+
+    if !config.storage.enabled {
+        info!("Storage disabled in configuration");
+        return None;
+    }
+
+    info!(url = %config.storage.url, "Connecting to Qdrant...");
+
+    match QdrantStorage::new(&config.storage.url, config.storage.collection_prefix.clone()).await {
+        Ok(storage) => {
+            if let Err(e) = storage.initialize().await {
+                error!("Failed to initialize storage collections: {e}");
+                warn!("Starting without vector storage capability");
+                return None;
+            }
+            info!("Qdrant storage connected and initialized");
+            Some(storage)
+        }
+        Err(e) => {
+            error!("Failed to connect to Qdrant: {e}");
+            warn!("Starting without vector storage capability");
+            None
+        }
+    }
+}
+
+/// Create application state with inference only
+#[cfg(all(feature = "inference", not(feature = "storage")))]
 async fn create_app_state(config: AppConfig) -> server::AppState {
     use insight_sidecar::inference::{download_model, ClapModel};
 
     info!(model = %config.model.name, "Downloading/loading CLAP model...");
 
-    // Download model files
     match download_model(&config.model.name, None).await {
         Ok(paths) => {
             info!(?paths, "Model files ready, loading into ONNX Runtime...");
-
-            // Load model into ONNX Runtime (blocking operation)
             let use_cuda = config.model.enable_cuda;
             match tokio::task::spawn_blocking(move || ClapModel::load(&paths, use_cuda)).await {
                 Ok(Ok(model)) => {
@@ -96,9 +178,40 @@ async fn create_app_state(config: AppConfig) -> server::AppState {
     }
 }
 
-#[cfg(not(feature = "inference"))]
+/// Create application state with storage only
+#[cfg(all(feature = "storage", not(feature = "inference")))]
 async fn create_app_state(config: AppConfig) -> server::AppState {
-    info!("Inference feature not enabled, starting without ML model");
+    use insight_sidecar::storage::{QdrantStorage, VectorStorage};
+
+    if !config.storage.enabled {
+        info!("Storage disabled in configuration");
+        return server::AppState::new(config);
+    }
+
+    info!(url = %config.storage.url, "Connecting to Qdrant...");
+
+    match QdrantStorage::new(&config.storage.url, config.storage.collection_prefix.clone()).await {
+        Ok(storage) => {
+            if let Err(e) = storage.initialize().await {
+                error!("Failed to initialize storage collections: {e}");
+                warn!("Starting without vector storage capability");
+                return server::AppState::new(config);
+            }
+            info!("Qdrant storage connected and initialized");
+            server::AppState::with_storage(config, storage)
+        }
+        Err(e) => {
+            error!("Failed to connect to Qdrant: {e}");
+            warn!("Starting without vector storage capability");
+            server::AppState::new(config)
+        }
+    }
+}
+
+/// Create application state without optional features
+#[cfg(not(any(feature = "inference", feature = "storage")))]
+async fn create_app_state(config: AppConfig) -> server::AppState {
+    info!("No optional features enabled");
     server::AppState::new(config)
 }
 

--- a/src/server/extractors.rs
+++ b/src/server/extractors.rs
@@ -1,0 +1,108 @@
+//! Custom extractors for the HTTP server.
+
+use axum::{
+    async_trait,
+    body::Bytes,
+    extract::{FromRequest, Request},
+    http::{header::CONTENT_TYPE, StatusCode},
+    response::{IntoResponse, Response},
+};
+use serde::de::DeserializeOwned;
+
+/// Rejection type for MsgPackExtractor
+pub struct MsgPackRejection {
+    message: String,
+}
+
+impl IntoResponse for MsgPackRejection {
+    fn into_response(self) -> Response {
+        let body = crate::error::ErrorResponse {
+            error: crate::error::ErrorDetail {
+                code: "DESERIALIZATION_ERROR",
+                message: self.message,
+            },
+        };
+
+        match rmp_serde::to_vec(&body) {
+            Ok(bytes) => (
+                StatusCode::BAD_REQUEST,
+                [("content-type", "application/msgpack")],
+                bytes,
+            )
+                .into_response(),
+            Err(_) => (StatusCode::BAD_REQUEST, self.message).into_response(),
+        }
+    }
+}
+
+/// Extractor for MessagePack request bodies.
+///
+/// This extractor deserializes the request body from MessagePack format.
+/// It accepts both `application/msgpack` and `application/x-msgpack` content types.
+pub struct MsgPackExtractor<T>(pub T);
+
+#[async_trait]
+impl<T, S> FromRequest<S> for MsgPackExtractor<T>
+where
+    T: DeserializeOwned,
+    S: Send + Sync,
+{
+    type Rejection = MsgPackRejection;
+
+    async fn from_request(req: Request, state: &S) -> Result<Self, Self::Rejection> {
+        // Check content type
+        let content_type = req
+            .headers()
+            .get(CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("");
+
+        if !content_type.contains("msgpack") && !content_type.is_empty() {
+            return Err(MsgPackRejection {
+                message: format!(
+                    "Invalid content type: expected application/msgpack, got {}",
+                    content_type
+                ),
+            });
+        }
+
+        // Extract body bytes
+        let bytes = Bytes::from_request(req, state).await.map_err(|e| {
+            MsgPackRejection {
+                message: format!("Failed to read request body: {e}"),
+            }
+        })?;
+
+        // Deserialize from MessagePack
+        rmp_serde::from_slice(&bytes).map(MsgPackExtractor).map_err(|e| {
+            MsgPackRejection {
+                message: format!("Failed to deserialize MessagePack: {e}"),
+            }
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::{Deserialize, Serialize};
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq)]
+    struct TestPayload {
+        name: String,
+        value: i32,
+    }
+
+    #[test]
+    fn test_msgpack_roundtrip() {
+        let payload = TestPayload {
+            name: "test".to_string(),
+            value: 42,
+        };
+
+        let bytes = rmp_serde::to_vec(&payload).unwrap();
+        let decoded: TestPayload = rmp_serde::from_slice(&bytes).unwrap();
+
+        assert_eq!(payload, decoded);
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -11,12 +11,17 @@ use crate::config::AppConfig;
 #[cfg(feature = "inference")]
 use crate::inference::ClapModel;
 
+#[cfg(feature = "storage")]
+use crate::storage::QdrantStorage;
+
 /// Shared application state passed to all handlers
 #[derive(Clone)]
 pub struct AppState {
     pub config: Arc<AppConfig>,
     #[cfg(feature = "inference")]
     pub model: Option<Arc<ClapModel>>,
+    #[cfg(feature = "storage")]
+    pub storage: Option<Arc<QdrantStorage>>,
 }
 
 impl AppState {
@@ -25,6 +30,8 @@ impl AppState {
             config: Arc::new(config),
             #[cfg(feature = "inference")]
             model: None,
+            #[cfg(feature = "storage")]
+            storage: None,
         }
     }
 
@@ -34,6 +41,29 @@ impl AppState {
         Self {
             config: Arc::new(config),
             model: Some(Arc::new(model)),
+            #[cfg(feature = "storage")]
+            storage: None,
+        }
+    }
+
+    /// Create AppState with storage
+    #[cfg(feature = "storage")]
+    pub fn with_storage(config: AppConfig, storage: QdrantStorage) -> Self {
+        Self {
+            config: Arc::new(config),
+            #[cfg(feature = "inference")]
+            model: None,
+            storage: Some(Arc::new(storage)),
+        }
+    }
+
+    /// Create AppState with both model and storage
+    #[cfg(all(feature = "inference", feature = "storage"))]
+    pub fn with_model_and_storage(config: AppConfig, model: ClapModel, storage: QdrantStorage) -> Self {
+        Self {
+            config: Arc::new(config),
+            model: Some(Arc::new(model)),
+            storage: Some(Arc::new(storage)),
         }
     }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -9,6 +9,7 @@ mod qdrant;
 #[cfg(feature = "storage")]
 pub use qdrant::QdrantStorage;
 
+use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 
 /// Error type for storage operations
@@ -157,7 +158,7 @@ impl SearchFilter {
 }
 
 /// Trait for vector storage backends
-#[allow(async_fn_in_trait)]
+#[async_trait]
 pub trait VectorStorage: Send + Sync {
     /// Initialize storage and create collections if needed
     async fn initialize(&self) -> Result<(), StorageError>;

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,0 +1,238 @@
+//! Vector storage module for track embeddings.
+//!
+//! This module provides a storage abstraction for vector embeddings,
+//! with an implementation using Qdrant as the vector database.
+
+#[cfg(feature = "storage")]
+mod qdrant;
+
+#[cfg(feature = "storage")]
+pub use qdrant::QdrantStorage;
+
+use serde::{Deserialize, Serialize};
+
+/// Error type for storage operations
+#[derive(Debug, thiserror::Error)]
+pub enum StorageError {
+    #[error("Connection failed: {0}")]
+    ConnectionFailed(String),
+
+    #[error("Collection not found: {0}")]
+    CollectionNotFound(String),
+
+    #[error("Point not found: {0}")]
+    PointNotFound(String),
+
+    #[error("Invalid embedding dimension: expected {expected}, got {got}")]
+    InvalidDimension { expected: usize, got: usize },
+
+    #[error("Storage operation failed: {0}")]
+    OperationFailed(String),
+
+    #[error("Serialization error: {0}")]
+    SerializationError(String),
+}
+
+/// Expected embedding dimension for CLAP models
+pub const EMBEDDING_DIM: usize = 512;
+
+/// Collection names for different embedding types
+pub const TEXT_COLLECTION: &str = "tracks_text";
+pub const AUDIO_COLLECTION: &str = "tracks_audio";
+
+/// Metadata stored with each embedding
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackMetadata {
+    /// Music Assistant item_id
+    pub track_id: String,
+    /// Track name
+    pub name: String,
+    /// Artist names
+    pub artists: Vec<String>,
+    /// Album name
+    pub album: Option<String>,
+    /// Genre tags
+    pub genres: Vec<String>,
+    /// Unix timestamp of last update
+    pub updated_at: i64,
+}
+
+impl TrackMetadata {
+    /// Create new track metadata
+    pub fn new(track_id: impl Into<String>, name: impl Into<String>) -> Self {
+        Self {
+            track_id: track_id.into(),
+            name: name.into(),
+            artists: Vec::new(),
+            album: None,
+            genres: Vec::new(),
+            updated_at: std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(0),
+        }
+    }
+
+    /// Builder method to add artists
+    pub fn with_artists(mut self, artists: Vec<String>) -> Self {
+        self.artists = artists;
+        self
+    }
+
+    /// Builder method to add album
+    pub fn with_album(mut self, album: impl Into<String>) -> Self {
+        self.album = Some(album.into());
+        self
+    }
+
+    /// Builder method to add genres
+    pub fn with_genres(mut self, genres: Vec<String>) -> Self {
+        self.genres = genres;
+        self
+    }
+}
+
+/// Result of a similarity search
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResult {
+    /// Track ID
+    pub track_id: String,
+    /// Similarity score (0.0 to 1.0 for cosine similarity)
+    pub score: f32,
+    /// Track metadata
+    pub metadata: TrackMetadata,
+}
+
+/// A stored embedding with its metadata
+#[derive(Debug, Clone)]
+pub struct StoredEmbedding {
+    /// The embedding vector
+    pub embedding: Vec<f32>,
+    /// Associated metadata
+    pub metadata: TrackMetadata,
+}
+
+/// Filter for search operations
+#[derive(Debug, Clone, Default)]
+pub struct SearchFilter {
+    /// Filter by artist names (any match)
+    pub artists: Option<Vec<String>>,
+    /// Filter by genres (any match)
+    pub genres: Option<Vec<String>>,
+    /// Filter by album name
+    pub album: Option<String>,
+    /// Exclude specific track IDs
+    pub exclude_ids: Option<Vec<String>>,
+}
+
+impl SearchFilter {
+    /// Create a new empty filter
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Filter by artists
+    pub fn with_artists(mut self, artists: Vec<String>) -> Self {
+        self.artists = Some(artists);
+        self
+    }
+
+    /// Filter by genres
+    pub fn with_genres(mut self, genres: Vec<String>) -> Self {
+        self.genres = Some(genres);
+        self
+    }
+
+    /// Filter by album
+    pub fn with_album(mut self, album: impl Into<String>) -> Self {
+        self.album = Some(album.into());
+        self
+    }
+
+    /// Exclude specific track IDs
+    pub fn exclude(mut self, ids: Vec<String>) -> Self {
+        self.exclude_ids = Some(ids);
+        self
+    }
+}
+
+/// Trait for vector storage backends
+#[allow(async_fn_in_trait)]
+pub trait VectorStorage: Send + Sync {
+    /// Initialize storage and create collections if needed
+    async fn initialize(&self) -> Result<(), StorageError>;
+
+    /// Upsert a single embedding
+    async fn upsert(
+        &self,
+        collection: &str,
+        track_id: &str,
+        embedding: &[f32],
+        metadata: TrackMetadata,
+    ) -> Result<(), StorageError>;
+
+    /// Upsert multiple embeddings in a batch
+    async fn upsert_batch(
+        &self,
+        collection: &str,
+        items: Vec<(String, Vec<f32>, TrackMetadata)>,
+    ) -> Result<(), StorageError>;
+
+    /// Search for similar embeddings
+    async fn search(
+        &self,
+        collection: &str,
+        query: &[f32],
+        limit: usize,
+        filter: Option<SearchFilter>,
+    ) -> Result<Vec<SearchResult>, StorageError>;
+
+    /// Delete an embedding by track ID
+    async fn delete(&self, collection: &str, track_id: &str) -> Result<(), StorageError>;
+
+    /// Delete multiple embeddings by track IDs
+    async fn delete_batch(&self, collection: &str, track_ids: &[String]) -> Result<(), StorageError>;
+
+    /// Get an embedding by track ID
+    async fn get(&self, collection: &str, track_id: &str) -> Result<Option<StoredEmbedding>, StorageError>;
+
+    /// Check if a track exists in the collection
+    async fn exists(&self, collection: &str, track_id: &str) -> Result<bool, StorageError>;
+
+    /// Get the count of embeddings in a collection
+    async fn count(&self, collection: &str) -> Result<u64, StorageError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_track_metadata_builder() {
+        let metadata = TrackMetadata::new("track_123", "Test Song")
+            .with_artists(vec!["Artist 1".to_string(), "Artist 2".to_string()])
+            .with_album("Test Album")
+            .with_genres(vec!["rock".to_string(), "indie".to_string()]);
+
+        assert_eq!(metadata.track_id, "track_123");
+        assert_eq!(metadata.name, "Test Song");
+        assert_eq!(metadata.artists.len(), 2);
+        assert_eq!(metadata.album, Some("Test Album".to_string()));
+        assert_eq!(metadata.genres.len(), 2);
+        assert!(metadata.updated_at > 0);
+    }
+
+    #[test]
+    fn test_search_filter_builder() {
+        let filter = SearchFilter::new()
+            .with_artists(vec!["Artist 1".to_string()])
+            .with_genres(vec!["rock".to_string()])
+            .with_album("Album")
+            .exclude(vec!["track_1".to_string()]);
+
+        assert!(filter.artists.is_some());
+        assert!(filter.genres.is_some());
+        assert!(filter.album.is_some());
+        assert!(filter.exclude_ids.is_some());
+    }
+}

--- a/src/storage/qdrant.rs
+++ b/src/storage/qdrant.rs
@@ -1,5 +1,6 @@
 //! Qdrant vector database implementation.
 
+use async_trait::async_trait;
 use qdrant_client::qdrant::{
     point_id::PointIdOptions, Condition, CreateCollectionBuilder, DeletePointsBuilder, Distance,
     Filter, GetPointsBuilder, PointId, PointStruct, PointsIdsList, SearchPointsBuilder,
@@ -212,6 +213,7 @@ impl QdrantStorage {
     }
 }
 
+#[async_trait]
 impl VectorStorage for QdrantStorage {
     async fn initialize(&self) -> Result<(), StorageError> {
         info!("Initializing Qdrant storage");

--- a/src/storage/qdrant.rs
+++ b/src/storage/qdrant.rs
@@ -1,0 +1,464 @@
+//! Qdrant vector database implementation.
+
+use qdrant_client::qdrant::{
+    point_id::PointIdOptions, Condition, CreateCollectionBuilder, DeletePointsBuilder, Distance,
+    Filter, GetPointsBuilder, PointId, PointStruct, PointsIdsList, SearchPointsBuilder,
+    UpsertPointsBuilder, Value as QdrantValue, VectorParamsBuilder,
+};
+use qdrant_client::{Payload, Qdrant};
+use serde_json::json;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{debug, info};
+
+use super::{
+    SearchFilter, SearchResult, StorageError, StoredEmbedding, TrackMetadata, VectorStorage,
+    AUDIO_COLLECTION, EMBEDDING_DIM, TEXT_COLLECTION,
+};
+
+/// Qdrant-based vector storage implementation
+pub struct QdrantStorage {
+    client: Arc<Qdrant>,
+    /// Prefix for collection names
+    collection_prefix: String,
+}
+
+impl std::fmt::Debug for QdrantStorage {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QdrantStorage")
+            .field("collection_prefix", &self.collection_prefix)
+            .finish()
+    }
+}
+
+impl QdrantStorage {
+    /// Create a new Qdrant storage client
+    pub async fn new(url: &str, collection_prefix: Option<String>) -> Result<Self, StorageError> {
+        info!(%url, "Connecting to Qdrant");
+
+        let client = Qdrant::from_url(url)
+            .build()
+            .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
+
+        Ok(Self {
+            client: Arc::new(client),
+            collection_prefix: collection_prefix.unwrap_or_default(),
+        })
+    }
+
+    /// Get the full collection name with prefix
+    fn collection_name(&self, base: &str) -> String {
+        if self.collection_prefix.is_empty() {
+            base.to_string()
+        } else {
+            format!("{}_{}", self.collection_prefix, base)
+        }
+    }
+
+    /// Create a collection if it doesn't exist
+    async fn ensure_collection(&self, name: &str) -> Result<(), StorageError> {
+        let full_name = self.collection_name(name);
+
+        let exists = self
+            .client
+            .collection_exists(&full_name)
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        if !exists {
+            info!(collection = %full_name, dim = EMBEDDING_DIM, "Creating collection");
+
+            self.client
+                .create_collection(
+                    CreateCollectionBuilder::new(&full_name)
+                        .vectors_config(VectorParamsBuilder::new(
+                            EMBEDDING_DIM as u64,
+                            Distance::Cosine,
+                        )),
+                )
+                .await
+                .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+            info!(collection = %full_name, "Collection created");
+        } else {
+            debug!(collection = %full_name, "Collection already exists");
+        }
+
+        Ok(())
+    }
+
+    /// Convert TrackMetadata to Qdrant Payload
+    fn metadata_to_payload(metadata: &TrackMetadata) -> Payload {
+        Payload::try_from(json!({
+            "track_id": metadata.track_id,
+            "name": metadata.name,
+            "artists": metadata.artists,
+            "album": metadata.album,
+            "genres": metadata.genres,
+            "updated_at": metadata.updated_at,
+        }))
+        .unwrap_or_default()
+    }
+
+    /// Convert Qdrant payload to TrackMetadata
+    fn payload_to_metadata(
+        payload: &HashMap<String, QdrantValue>,
+    ) -> Result<TrackMetadata, StorageError> {
+        let track_id = payload
+            .get("track_id")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .ok_or_else(|| StorageError::SerializationError("Missing track_id".to_string()))?;
+
+        let name = payload
+            .get("name")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .unwrap_or_default();
+
+        let artists = payload
+            .get("artists")
+            .and_then(|v| v.as_list())
+            .map(|list| {
+                list.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let album = payload
+            .get("album")
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+
+        let genres = payload
+            .get("genres")
+            .and_then(|v| v.as_list())
+            .map(|list| {
+                list.iter()
+                    .filter_map(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let updated_at = payload
+            .get("updated_at")
+            .and_then(|v| v.as_integer())
+            .unwrap_or(0);
+
+        Ok(TrackMetadata {
+            track_id,
+            name,
+            artists,
+            album,
+            genres,
+            updated_at,
+        })
+    }
+
+    /// Build a Qdrant filter from SearchFilter
+    fn build_filter(filter: &SearchFilter) -> Option<Filter> {
+        let mut conditions: Vec<Condition> = Vec::new();
+
+        if let Some(ref artists) = filter.artists {
+            for artist in artists {
+                conditions.push(Condition::matches("artists", artist.clone()));
+            }
+        }
+
+        if let Some(ref genres) = filter.genres {
+            for genre in genres {
+                conditions.push(Condition::matches("genres", genre.clone()));
+            }
+        }
+
+        if let Some(ref album) = filter.album {
+            conditions.push(Condition::matches("album", album.clone()));
+        }
+
+        // Handle exclusions
+        let mut must_not: Vec<Condition> = Vec::new();
+        if let Some(ref exclude_ids) = filter.exclude_ids {
+            for id in exclude_ids {
+                must_not.push(Condition::matches("track_id", id.clone()));
+            }
+        }
+
+        if conditions.is_empty() && must_not.is_empty() {
+            None
+        } else if must_not.is_empty() {
+            Some(Filter::should(conditions))
+        } else if conditions.is_empty() {
+            Some(Filter::must_not(must_not))
+        } else {
+            Some(Filter {
+                should: conditions,
+                must_not,
+                ..Default::default()
+            })
+        }
+    }
+
+    /// Generate a deterministic point ID from track_id
+    fn track_id_to_point_id(track_id: &str) -> PointId {
+        // Use the track_id string directly as the point ID
+        PointId {
+            point_id_options: Some(PointIdOptions::Uuid(
+                uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_OID, track_id.as_bytes()).to_string(),
+            )),
+        }
+    }
+}
+
+impl VectorStorage for QdrantStorage {
+    async fn initialize(&self) -> Result<(), StorageError> {
+        info!("Initializing Qdrant storage");
+
+        // Create both collections
+        self.ensure_collection(TEXT_COLLECTION).await?;
+        self.ensure_collection(AUDIO_COLLECTION).await?;
+
+        info!("Qdrant storage initialized");
+        Ok(())
+    }
+
+    async fn upsert(
+        &self,
+        collection: &str,
+        track_id: &str,
+        embedding: &[f32],
+        metadata: TrackMetadata,
+    ) -> Result<(), StorageError> {
+        if embedding.len() != EMBEDDING_DIM {
+            return Err(StorageError::InvalidDimension {
+                expected: EMBEDDING_DIM,
+                got: embedding.len(),
+            });
+        }
+
+        let full_name = self.collection_name(collection);
+        let point_id = Self::track_id_to_point_id(track_id);
+        let payload = Self::metadata_to_payload(&metadata);
+
+        debug!(collection = %full_name, %track_id, "Upserting point");
+
+        let point = PointStruct::new(point_id, embedding.to_vec(), payload);
+
+        self.client
+            .upsert_points(UpsertPointsBuilder::new(&full_name, vec![point]).wait(true))
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn upsert_batch(
+        &self,
+        collection: &str,
+        items: Vec<(String, Vec<f32>, TrackMetadata)>,
+    ) -> Result<(), StorageError> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
+        // Validate dimensions
+        for (_track_id, embedding, _) in &items {
+            if embedding.len() != EMBEDDING_DIM {
+                return Err(StorageError::InvalidDimension {
+                    expected: EMBEDDING_DIM,
+                    got: embedding.len(),
+                });
+            }
+        }
+
+        let full_name = self.collection_name(collection);
+        debug!(collection = %full_name, count = items.len(), "Batch upserting points");
+
+        let points: Vec<PointStruct> = items
+            .into_iter()
+            .map(|(track_id, embedding, metadata)| {
+                let point_id = Self::track_id_to_point_id(&track_id);
+                let payload = Self::metadata_to_payload(&metadata);
+                PointStruct::new(point_id, embedding, payload)
+            })
+            .collect();
+
+        self.client
+            .upsert_points(UpsertPointsBuilder::new(&full_name, points).wait(true))
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn search(
+        &self,
+        collection: &str,
+        query: &[f32],
+        limit: usize,
+        filter: Option<SearchFilter>,
+    ) -> Result<Vec<SearchResult>, StorageError> {
+        if query.len() != EMBEDDING_DIM {
+            return Err(StorageError::InvalidDimension {
+                expected: EMBEDDING_DIM,
+                got: query.len(),
+            });
+        }
+
+        let full_name = self.collection_name(collection);
+        debug!(collection = %full_name, %limit, "Searching points");
+
+        let mut search_builder =
+            SearchPointsBuilder::new(&full_name, query.to_vec(), limit as u64).with_payload(true);
+
+        if let Some(ref f) = filter {
+            if let Some(qdrant_filter) = Self::build_filter(f) {
+                search_builder = search_builder.filter(qdrant_filter);
+            }
+        }
+
+        let response = self
+            .client
+            .search_points(search_builder)
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        let results = response
+            .result
+            .into_iter()
+            .filter_map(|scored_point| {
+                let payload = scored_point.payload;
+                let metadata = Self::payload_to_metadata(&payload).ok()?;
+                Some(SearchResult {
+                    track_id: metadata.track_id.clone(),
+                    score: scored_point.score,
+                    metadata,
+                })
+            })
+            .collect();
+
+        Ok(results)
+    }
+
+    async fn delete(&self, collection: &str, track_id: &str) -> Result<(), StorageError> {
+        let full_name = self.collection_name(collection);
+        let point_id = Self::track_id_to_point_id(track_id);
+
+        debug!(collection = %full_name, %track_id, "Deleting point");
+
+        self.client
+            .delete_points(
+                DeletePointsBuilder::new(&full_name)
+                    .points(PointsIdsList {
+                        ids: vec![point_id],
+                    })
+                    .wait(true),
+            )
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn delete_batch(&self, collection: &str, track_ids: &[String]) -> Result<(), StorageError> {
+        if track_ids.is_empty() {
+            return Ok(());
+        }
+
+        let full_name = self.collection_name(collection);
+        debug!(collection = %full_name, count = track_ids.len(), "Batch deleting points");
+
+        let point_ids: Vec<PointId> = track_ids
+            .iter()
+            .map(|id| Self::track_id_to_point_id(id))
+            .collect();
+
+        self.client
+            .delete_points(
+                DeletePointsBuilder::new(&full_name)
+                    .points(PointsIdsList { ids: point_ids })
+                    .wait(true),
+            )
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get(&self, collection: &str, track_id: &str) -> Result<Option<StoredEmbedding>, StorageError> {
+        let full_name = self.collection_name(collection);
+        let point_id = Self::track_id_to_point_id(track_id);
+
+        debug!(collection = %full_name, %track_id, "Getting point");
+
+        let response = self
+            .client
+            .get_points(
+                GetPointsBuilder::new(&full_name, vec![point_id])
+                    .with_payload(true)
+                    .with_vectors(true),
+            )
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        if let Some(point) = response.result.into_iter().next() {
+            let metadata = Self::payload_to_metadata(&point.payload)?;
+
+            // Extract vector using the vectors_output module
+            #[allow(deprecated)]
+            let embedding = point
+                .vectors
+                .and_then(|v| v.vectors_options)
+                .and_then(|opts| {
+                    use qdrant_client::qdrant::vectors_output::VectorsOptions;
+                    match opts {
+                        VectorsOptions::Vector(v) => Some(v.data.clone()),
+                        _ => None,
+                    }
+                })
+                .unwrap_or_default();
+
+            Ok(Some(StoredEmbedding {
+                embedding,
+                metadata,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    async fn exists(&self, collection: &str, track_id: &str) -> Result<bool, StorageError> {
+        let full_name = self.collection_name(collection);
+        let point_id = Self::track_id_to_point_id(track_id);
+
+        let response = self
+            .client
+            .get_points(
+                GetPointsBuilder::new(&full_name, vec![point_id])
+                    .with_payload(false)
+                    .with_vectors(false),
+            )
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(!response.result.is_empty())
+    }
+
+    async fn count(&self, collection: &str) -> Result<u64, StorageError> {
+        let full_name = self.collection_name(collection);
+
+        let info = self
+            .client
+            .collection_info(&full_name)
+            .await
+            .map_err(|e| StorageError::OperationFailed(e.to_string()))?;
+
+        Ok(info.result.map(|r| r.points_count.unwrap_or(0)).unwrap_or(0))
+    }
+}
+
+/// Thread-safe wrapper for QdrantStorage
+#[allow(dead_code)]
+pub type SharedQdrantStorage = Arc<QdrantStorage>;

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -1,0 +1,226 @@
+//! API request and response types for track operations.
+
+use serde::{Deserialize, Serialize};
+
+use crate::storage::{SearchFilter, SearchResult, TrackMetadata};
+
+/// Request to upsert track embedding(s)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertRequest {
+    /// Track ID (Music Assistant item_id)
+    pub track_id: String,
+    /// Track metadata
+    pub metadata: TrackMetadataInput,
+    /// Text embedding (512-dimensional)
+    #[serde(default)]
+    pub text_embedding: Option<Vec<f32>>,
+    /// Audio embedding (512-dimensional)
+    #[serde(default)]
+    pub audio_embedding: Option<Vec<f32>>,
+}
+
+/// Input metadata for upsert operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TrackMetadataInput {
+    /// Track name
+    pub name: String,
+    /// Artist names
+    #[serde(default)]
+    pub artists: Vec<String>,
+    /// Album name
+    #[serde(default)]
+    pub album: Option<String>,
+    /// Genre tags
+    #[serde(default)]
+    pub genres: Vec<String>,
+}
+
+impl TrackMetadataInput {
+    /// Convert to storage TrackMetadata
+    pub fn into_storage(self, track_id: String) -> TrackMetadata {
+        let mut metadata = TrackMetadata::new(track_id, self.name)
+            .with_artists(self.artists)
+            .with_genres(self.genres);
+
+        if let Some(album) = self.album {
+            metadata = metadata.with_album(album);
+        }
+
+        metadata
+    }
+}
+
+/// Response from upsert operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpsertResponse {
+    /// Track ID that was upserted
+    pub track_id: String,
+    /// Whether text embedding was stored
+    pub text_stored: bool,
+    /// Whether audio embedding was stored
+    pub audio_stored: bool,
+}
+
+/// Request to search for similar tracks
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchRequest {
+    /// Query embedding (512-dimensional)
+    pub embedding: Vec<f32>,
+    /// Collection to search: "text" or "audio"
+    pub collection: String,
+    /// Maximum number of results (default: 10)
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+    /// Optional filter
+    #[serde(default)]
+    pub filter: Option<SearchFilterInput>,
+}
+
+fn default_limit() -> usize {
+    10
+}
+
+/// Input filter for search operations
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchFilterInput {
+    /// Filter by artist names (any match)
+    #[serde(default)]
+    pub artists: Option<Vec<String>>,
+    /// Filter by genres (any match)
+    #[serde(default)]
+    pub genres: Option<Vec<String>>,
+    /// Filter by album name
+    #[serde(default)]
+    pub album: Option<String>,
+    /// Exclude specific track IDs
+    #[serde(default)]
+    pub exclude_ids: Option<Vec<String>>,
+}
+
+impl From<SearchFilterInput> for SearchFilter {
+    fn from(input: SearchFilterInput) -> Self {
+        let mut filter = SearchFilter::new();
+
+        if let Some(artists) = input.artists {
+            filter = filter.with_artists(artists);
+        }
+        if let Some(genres) = input.genres {
+            filter = filter.with_genres(genres);
+        }
+        if let Some(album) = input.album {
+            filter = filter.with_album(album);
+        }
+        if let Some(exclude_ids) = input.exclude_ids {
+            filter = filter.exclude(exclude_ids);
+        }
+
+        filter
+    }
+}
+
+/// Response from search operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SearchResponse {
+    /// Search results sorted by similarity
+    pub results: Vec<SearchResult>,
+    /// Number of results returned
+    pub count: usize,
+}
+
+/// Request to delete a track's embeddings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteRequest {
+    /// Delete from text collection
+    #[serde(default = "default_true")]
+    pub text: bool,
+    /// Delete from audio collection
+    #[serde(default = "default_true")]
+    pub audio: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+impl Default for DeleteRequest {
+    fn default() -> Self {
+        Self {
+            text: true,
+            audio: true,
+        }
+    }
+}
+
+/// Response from delete operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteResponse {
+    /// Track ID that was deleted
+    pub track_id: String,
+    /// Whether text embedding was deleted
+    pub text_deleted: bool,
+    /// Whether audio embedding was deleted
+    pub audio_deleted: bool,
+}
+
+/// Response for get track operation
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTrackResponse {
+    /// Track ID
+    pub track_id: String,
+    /// Track metadata (from either collection)
+    pub metadata: Option<TrackMetadata>,
+    /// Whether text embedding exists
+    pub has_text: bool,
+    /// Whether audio embedding exists
+    pub has_audio: bool,
+    /// Text embedding if requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_embedding: Option<Vec<f32>>,
+    /// Audio embedding if requested
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub audio_embedding: Option<Vec<f32>>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_upsert_request_serialize() {
+        let req = UpsertRequest {
+            track_id: "track_123".to_string(),
+            metadata: TrackMetadataInput {
+                name: "Test Song".to_string(),
+                artists: vec!["Artist 1".to_string()],
+                album: Some("Album".to_string()),
+                genres: vec!["rock".to_string()],
+            },
+            text_embedding: Some(vec![0.1; 512]),
+            audio_embedding: None,
+        };
+
+        let bytes = rmp_serde::to_vec(&req).unwrap();
+        let decoded: UpsertRequest = rmp_serde::from_slice(&bytes).unwrap();
+
+        assert_eq!(decoded.track_id, "track_123");
+        assert!(decoded.text_embedding.is_some());
+        assert!(decoded.audio_embedding.is_none());
+    }
+
+    #[test]
+    fn test_search_filter_conversion() {
+        let input = SearchFilterInput {
+            artists: Some(vec!["Artist".to_string()]),
+            genres: Some(vec!["rock".to_string()]),
+            album: Some("Album".to_string()),
+            exclude_ids: Some(vec!["track_1".to_string()]),
+        };
+
+        let filter: SearchFilter = input.into();
+
+        assert!(filter.artists.is_some());
+        assert!(filter.genres.is_some());
+        assert!(filter.album.is_some());
+        assert!(filter.exclude_ids.is_some());
+    }
+}

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Serialize};
 pub struct HealthResponse {
     pub status: HealthStatus,
     pub version: String,
+    #[serde(default)]
     pub model_loaded: bool,
+    #[serde(default)]
+    pub storage_ready: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -27,6 +30,7 @@ pub struct ConfigResponse {
     pub model: ModelInfo,
     pub audio: AudioInfo,
     pub server: ServerInfo,
+    pub storage: StorageInfo,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -47,4 +51,11 @@ pub struct AudioInfo {
 pub struct ServerInfo {
     pub host: String,
     pub port: u16,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StorageInfo {
+    pub url: String,
+    pub enabled: bool,
+    pub connected: bool,
 }


### PR DESCRIPTION
## Summary
- Add vector storage capability using Qdrant for storing and searching track embeddings
- Implement `VectorStorage` trait with async CRUD operations
- Create `QdrantStorage` implementation with connection pooling
- Add two collections: `tracks_text` and `tracks_audio` (512-dim, cosine distance)
- Support batch operations for efficient bulk upserts
- Add `SearchFilter` for filtering by artists, genres, album
- Add storage status reporting in health and config endpoints

## Test plan
- [x] Run `cargo build --features storage` - compiles successfully
- [x] Run `cargo test --features storage` - 4 tests pass
- [x] Run `cargo clippy --features storage` - no warnings
- [x] Run `cargo build` (without features) - compiles successfully
- [ ] Test with running Qdrant instance (requires `docker run -p 6334:6334 qdrant/qdrant`)

Closes #5