### PR TITLE
feat: Phase 4 - HTTP API endpoints for track operations

### DIFF
--- a/src/server/extractors.rs
+++ b/src/server/extractors.rs
@@ -19,7 +19,7 @@ impl IntoResponse for MsgPackRejection {
         let body = crate::error::ErrorResponse {
             error: crate::error::ErrorDetail {
                 code: "DESERIALIZATION_ERROR",
-                message: self.message,
+                message: self.message.clone(),
             },
         };
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,8 +1,13 @@
 //! HTTP server setup and routing.
 
+mod extractors;
 mod routes;
+mod tracks;
 
-use axum::{routing::get, Router};
+use axum::{
+    routing::{get, post},
+    Router,
+};
 use std::sync::Arc;
 use tower_http::trace::TraceLayer;
 
@@ -78,7 +83,14 @@ impl AppState {
 pub fn create_router(state: AppState) -> Router {
     let api_routes = Router::new()
         .route("/health", get(routes::health))
-        .route("/config", get(routes::config));
+        .route("/config", get(routes::config))
+        // Track embedding endpoints
+        .route("/tracks/upsert", post(tracks::upsert))
+        .route("/tracks/search", post(tracks::search))
+        .route(
+            "/tracks/{id}",
+            get(tracks::get_track).delete(tracks::delete_track),
+        );
 
     Router::new()
         .nest("/api/v1", api_routes)

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -88,7 +88,7 @@ pub fn create_router(state: AppState) -> Router {
         .route("/tracks/upsert", post(tracks::upsert))
         .route("/tracks/search", post(tracks::search))
         .route(
-            "/tracks/{id}",
+            "/tracks/:id",
             get(tracks::get_track).delete(tracks::delete_track),
         );
 

--- a/src/server/tracks.rs
+++ b/src/server/tracks.rs
@@ -1,0 +1,334 @@
+//! Track embedding route handlers.
+
+use axum::extract::{Path, Query, State};
+use serde::Deserialize;
+
+use crate::error::AppError;
+use crate::types::{
+    DeleteRequest, DeleteResponse, GetTrackResponse, SearchRequest, SearchResponse,
+    UpsertRequest, UpsertResponse,
+};
+
+use super::extractors::MsgPackExtractor;
+use super::routes::MsgPack;
+use super::AppState;
+
+#[cfg(feature = "storage")]
+use crate::storage::{VectorStorage, AUDIO_COLLECTION, EMBEDDING_DIM, TEXT_COLLECTION};
+
+#[cfg(feature = "storage")]
+use tracing::{debug, error, info};
+
+/// POST /api/v1/tracks/upsert
+///
+/// Upsert track embedding(s) to the vector store.
+#[cfg(feature = "storage")]
+pub async fn upsert(
+    State(state): State<AppState>,
+    MsgPackExtractor(req): MsgPackExtractor<UpsertRequest>,
+) -> Result<MsgPack<UpsertResponse>, AppError> {
+    let storage = state
+        .storage
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
+
+    info!(track_id = %req.track_id, "Upserting track embeddings");
+
+    let mut text_stored = false;
+    let mut audio_stored = false;
+
+    let metadata = req.metadata.into_storage(req.track_id.clone());
+
+    // Store text embedding if provided
+    if let Some(ref embedding) = req.text_embedding {
+        if embedding.len() != EMBEDDING_DIM {
+            return Err(AppError::BadRequest(format!(
+                "Text embedding dimension mismatch: expected {}, got {}",
+                EMBEDDING_DIM,
+                embedding.len()
+            )));
+        }
+
+        storage
+            .upsert(TEXT_COLLECTION, &req.track_id, embedding, metadata.clone())
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Failed to upsert text embedding");
+                AppError::Internal(e.to_string())
+            })?;
+
+        text_stored = true;
+        debug!(track_id = %req.track_id, "Text embedding stored");
+    }
+
+    // Store audio embedding if provided
+    if let Some(ref embedding) = req.audio_embedding {
+        if embedding.len() != EMBEDDING_DIM {
+            return Err(AppError::BadRequest(format!(
+                "Audio embedding dimension mismatch: expected {}, got {}",
+                EMBEDDING_DIM,
+                embedding.len()
+            )));
+        }
+
+        storage
+            .upsert(AUDIO_COLLECTION, &req.track_id, embedding, metadata)
+            .await
+            .map_err(|e| {
+                error!(error = %e, "Failed to upsert audio embedding");
+                AppError::Internal(e.to_string())
+            })?;
+
+        audio_stored = true;
+        debug!(track_id = %req.track_id, "Audio embedding stored");
+    }
+
+    if !text_stored && !audio_stored {
+        return Err(AppError::BadRequest(
+            "At least one embedding (text or audio) must be provided".to_string(),
+        ));
+    }
+
+    Ok(MsgPack(UpsertResponse {
+        track_id: req.track_id,
+        text_stored,
+        audio_stored,
+    }))
+}
+
+/// POST /api/v1/tracks/search
+///
+/// Search for similar tracks by embedding.
+#[cfg(feature = "storage")]
+pub async fn search(
+    State(state): State<AppState>,
+    MsgPackExtractor(req): MsgPackExtractor<SearchRequest>,
+) -> Result<MsgPack<SearchResponse>, AppError> {
+    let storage = state
+        .storage
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
+
+    // Validate embedding dimension
+    if req.embedding.len() != EMBEDDING_DIM {
+        return Err(AppError::BadRequest(format!(
+            "Embedding dimension mismatch: expected {}, got {}",
+            EMBEDDING_DIM,
+            req.embedding.len()
+        )));
+    }
+
+    // Determine collection
+    let collection = match req.collection.as_str() {
+        "text" => TEXT_COLLECTION,
+        "audio" => AUDIO_COLLECTION,
+        _ => {
+            return Err(AppError::BadRequest(format!(
+                "Invalid collection '{}': must be 'text' or 'audio'",
+                req.collection
+            )))
+        }
+    };
+
+    let limit = req.limit.min(100); // Cap at 100 results
+
+    debug!(collection, limit, "Searching for similar tracks");
+
+    let filter = req.filter.map(Into::into);
+
+    let results = storage
+        .search(collection, &req.embedding, limit, filter)
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Search failed");
+            AppError::Internal(e.to_string())
+        })?;
+
+    let count = results.len();
+
+    Ok(MsgPack(SearchResponse { results, count }))
+}
+
+/// Query parameters for GET /api/v1/tracks/{id}
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct GetTrackQuery {
+    /// Include text embedding in response
+    #[serde(default)]
+    pub include_text: bool,
+    /// Include audio embedding in response
+    #[serde(default)]
+    pub include_audio: bool,
+}
+
+/// GET /api/v1/tracks/{id}
+///
+/// Get track embedding information.
+#[cfg(feature = "storage")]
+pub async fn get_track(
+    State(state): State<AppState>,
+    Path(track_id): Path<String>,
+    Query(query): Query<GetTrackQuery>,
+) -> Result<MsgPack<GetTrackResponse>, AppError> {
+    let storage = state
+        .storage
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
+
+    debug!(track_id = %track_id, "Getting track embeddings");
+
+    // Check text collection
+    let text_result = storage.get(TEXT_COLLECTION, &track_id).await.map_err(|e| {
+        error!(error = %e, "Failed to get text embedding");
+        AppError::Internal(e.to_string())
+    })?;
+
+    // Check audio collection
+    let audio_result = storage.get(AUDIO_COLLECTION, &track_id).await.map_err(|e| {
+        error!(error = %e, "Failed to get audio embedding");
+        AppError::Internal(e.to_string())
+    })?;
+
+    let has_text = text_result.is_some();
+    let has_audio = audio_result.is_some();
+
+    if !has_text && !has_audio {
+        return Err(AppError::NotFound(format!("Track '{}' not found", track_id)));
+    }
+
+    // Get metadata from whichever collection has data
+    let metadata = text_result
+        .as_ref()
+        .map(|r| r.metadata.clone())
+        .or_else(|| audio_result.as_ref().map(|r| r.metadata.clone()));
+
+    // Include embeddings if requested
+    let text_embedding = if query.include_text {
+        text_result.map(|r| r.embedding)
+    } else {
+        None
+    };
+
+    let audio_embedding = if query.include_audio {
+        audio_result.map(|r| r.embedding)
+    } else {
+        None
+    };
+
+    Ok(MsgPack(GetTrackResponse {
+        track_id,
+        metadata,
+        has_text,
+        has_audio,
+        text_embedding,
+        audio_embedding,
+    }))
+}
+
+/// DELETE /api/v1/tracks/{id}
+///
+/// Delete track embeddings.
+#[cfg(feature = "storage")]
+pub async fn delete_track(
+    State(state): State<AppState>,
+    Path(track_id): Path<String>,
+    body: Option<MsgPackExtractor<DeleteRequest>>,
+) -> Result<MsgPack<DeleteResponse>, AppError> {
+    let storage = state
+        .storage
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
+
+    let req = body.map(|b| b.0).unwrap_or_default();
+
+    info!(track_id = %track_id, text = req.text, audio = req.audio, "Deleting track embeddings");
+
+    let mut text_deleted = false;
+    let mut audio_deleted = false;
+
+    if req.text {
+        // Check if exists first
+        let exists = storage
+            .exists(TEXT_COLLECTION, &track_id)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        if exists {
+            storage
+                .delete(TEXT_COLLECTION, &track_id)
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "Failed to delete text embedding");
+                    AppError::Internal(e.to_string())
+                })?;
+            text_deleted = true;
+        }
+    }
+
+    if req.audio {
+        let exists = storage
+            .exists(AUDIO_COLLECTION, &track_id)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+
+        if exists {
+            storage
+                .delete(AUDIO_COLLECTION, &track_id)
+                .await
+                .map_err(|e| {
+                    error!(error = %e, "Failed to delete audio embedding");
+                    AppError::Internal(e.to_string())
+                })?;
+            audio_deleted = true;
+        }
+    }
+
+    Ok(MsgPack(DeleteResponse {
+        track_id,
+        text_deleted,
+        audio_deleted,
+    }))
+}
+
+/// Fallback handlers when storage feature is disabled
+#[cfg(not(feature = "storage"))]
+pub async fn upsert(
+    State(_state): State<AppState>,
+    MsgPackExtractor(_req): MsgPackExtractor<UpsertRequest>,
+) -> Result<MsgPack<UpsertResponse>, AppError> {
+    Err(AppError::Internal(
+        "Storage feature not enabled".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "storage"))]
+pub async fn search(
+    State(_state): State<AppState>,
+    MsgPackExtractor(_req): MsgPackExtractor<SearchRequest>,
+) -> Result<MsgPack<SearchResponse>, AppError> {
+    Err(AppError::Internal(
+        "Storage feature not enabled".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "storage"))]
+pub async fn get_track(
+    State(_state): State<AppState>,
+    Path(_track_id): Path<String>,
+    Query(_query): Query<GetTrackQuery>,
+) -> Result<MsgPack<GetTrackResponse>, AppError> {
+    Err(AppError::Internal(
+        "Storage feature not enabled".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "storage"))]
+pub async fn delete_track(
+    State(_state): State<AppState>,
+    Path(_track_id): Path<String>,
+    _body: Option<MsgPackExtractor<DeleteRequest>>,
+) -> Result<MsgPack<DeleteResponse>, AppError> {
+    Err(AppError::Internal(
+        "Storage feature not enabled".to_string(),
+    ))
+}

--- a/src/server/tracks.rs
+++ b/src/server/tracks.rs
@@ -225,21 +225,20 @@ pub async fn get_track(
     }))
 }
 
-/// DELETE /api/v1/tracks/{id}
+/// DELETE /api/v1/tracks/:id
 ///
-/// Delete track embeddings.
+/// Delete track embeddings. Request body is required to specify which
+/// collections to delete from (text, audio, or both).
 #[cfg(feature = "storage")]
 pub async fn delete_track(
     State(state): State<AppState>,
     Path(track_id): Path<String>,
-    body: Option<MsgPackExtractor<DeleteRequest>>,
+    MsgPackExtractor(req): MsgPackExtractor<DeleteRequest>,
 ) -> Result<MsgPack<DeleteResponse>, AppError> {
     let storage = state
         .storage
         .as_ref()
         .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
-
-    let req = body.map(|b| b.0).unwrap_or_default();
 
     info!(track_id = %track_id, text = req.text, audio = req.audio, "Deleting track embeddings");
 
@@ -326,7 +325,7 @@ pub async fn get_track(
 pub async fn delete_track(
     State(_state): State<AppState>,
     Path(_track_id): Path<String>,
-    _body: Option<MsgPackExtractor<DeleteRequest>>,
+    MsgPackExtractor(_req): MsgPackExtractor<DeleteRequest>,
 ) -> Result<MsgPack<DeleteResponse>, AppError> {
     Err(AppError::Internal(
         "Storage feature not enabled".to_string(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -3,7 +3,11 @@
 //! These types are used across the application for request/response handling
 //! and internal data representation.
 
+pub mod api;
+
 use serde::{Deserialize, Serialize};
+
+pub use api::*;
 
 /// Health check response
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary
- Add MsgPack request extractor for deserializing MessagePack request bodies
- Add API request/response types for track operations
- Implement four new endpoints:
  - `POST /api/v1/tracks/upsert` - store text/audio embeddings
  - `POST /api/v1/tracks/search` - similarity search by embedding  
  - `GET /api/v1/tracks/:id` - get track embedding info
  - `DELETE /api/v1/tracks/:id` - delete track embeddings (requires body)

## Test plan
- [x] Run `cargo build --features storage` - compiles successfully
- [x] Run `cargo build` (without features) - compiles successfully
- [x] Run `cargo test --features storage` - 7 tests pass
- [x] Run `cargo clippy --features storage` - no warnings
- [ ] Integration test with running Qdrant instance