### PR TITLE
feat: Phase 5 - Embedding generation endpoints

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ tokio = { version = "1", features = ["full"] }
 
 # Serialization
 serde = { version = "1", features = ["derive"] }
+serde_bytes = "0.11"
 serde_json = "1"
 rmp-serde = "1"
 

--- a/src/inference/mod.rs
+++ b/src/inference/mod.rs
@@ -11,7 +11,7 @@ mod text;
 pub use audio::{AudioData, AudioFormat, AudioProcessor};
 pub use download::{download_model, ModelPaths};
 pub use model::{ClapModel, Device};
-pub use text::format_track_metadata;
+pub use text::{format_track_metadata, TrackMetadata as TextTrackMetadata};
 
 use crate::error::AppError;
 

--- a/src/server/embed.rs
+++ b/src/server/embed.rs
@@ -1,0 +1,150 @@
+//! Embedding generation route handlers.
+
+use axum::extract::State;
+
+use crate::error::AppError;
+
+#[cfg(feature = "inference")]
+use crate::types::{AudioEmbedRequest, AudioEmbedResponse, TextEmbedRequest, TextEmbedResponse};
+
+#[cfg(feature = "inference")]
+use super::extractors::MsgPackExtractor;
+#[cfg(feature = "inference")]
+use super::routes::MsgPack;
+use super::AppState;
+
+#[cfg(feature = "inference")]
+use crate::inference::{format_track_metadata, AudioData, TextTrackMetadata};
+
+#[cfg(feature = "inference")]
+use tracing::{debug, error, info};
+
+/// POST /api/v1/embed/text
+///
+/// Generate text embedding from track metadata or raw text.
+#[cfg(feature = "inference")]
+pub async fn text_embed(
+    State(state): State<AppState>,
+    MsgPackExtractor(req): MsgPackExtractor<TextEmbedRequest>,
+) -> Result<MsgPack<TextEmbedResponse>, AppError> {
+    let model = state
+        .model
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Model not loaded".to_string()))?;
+
+    // Determine the text to embed
+    let text = if let Some(text) = req.text {
+        // Use raw text if provided
+        text
+    } else if let Some(metadata) = req.metadata {
+        // Format metadata into text
+        let track_meta = TextTrackMetadata {
+            name: metadata.name,
+            artists: metadata.artists,
+            album: metadata.album,
+            genres: metadata.genres,
+            mood: None,
+        };
+        format_track_metadata(&track_meta)
+    } else {
+        return Err(AppError::BadRequest(
+            "Either 'text' or 'metadata' must be provided".to_string(),
+        ));
+    };
+
+    info!(text_len = text.len(), "Generating text embedding");
+
+    // Generate embedding using the model
+    let embedding = tokio::task::spawn_blocking({
+        let model = model.clone();
+        let text = text.clone();
+        move || model.text_embedding(&text)
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "Text embedding task panicked");
+        AppError::Internal(e.to_string())
+    })?
+    .map_err(|e| {
+        error!(error = %e, "Text embedding failed");
+        AppError::from(e)
+    })?;
+
+    debug!(embedding_dim = embedding.data().len(), "Text embedding generated");
+
+    Ok(MsgPack(TextEmbedResponse {
+        embedding: embedding.into_data(),
+        text,
+    }))
+}
+
+/// POST /api/v1/embed/audio
+///
+/// Generate audio embedding from raw PCM audio data.
+#[cfg(feature = "inference")]
+pub async fn audio_embed(
+    State(state): State<AppState>,
+    MsgPackExtractor(req): MsgPackExtractor<AudioEmbedRequest>,
+) -> Result<MsgPack<AudioEmbedResponse>, AppError> {
+    let model = state
+        .model
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Model not loaded".to_string()))?;
+
+    // Convert request to AudioData
+    let audio_data: AudioData = req.into();
+
+    // Calculate duration for response
+    let samples_per_channel = match audio_data.format {
+        crate::inference::AudioFormat::PcmF32Le => audio_data.data.len() / 4,
+        crate::inference::AudioFormat::PcmS16Le => audio_data.data.len() / 2,
+        crate::inference::AudioFormat::PcmS24Le => audio_data.data.len() / 3,
+    };
+    let total_samples = samples_per_channel / audio_data.channels as usize;
+    let duration_s = total_samples as f32 / audio_data.sample_rate as f32;
+
+    info!(
+        format = ?audio_data.format,
+        sample_rate = audio_data.sample_rate,
+        channels = audio_data.channels,
+        duration_s,
+        "Generating audio embedding"
+    );
+
+    // Generate embedding using the model
+    let embedding = tokio::task::spawn_blocking({
+        let model = model.clone();
+        move || model.audio_embedding(&audio_data)
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "Audio embedding task panicked");
+        AppError::Internal(e.to_string())
+    })?
+    .map_err(|e| {
+        error!(error = %e, "Audio embedding failed");
+        AppError::from(e)
+    })?;
+
+    debug!(embedding_dim = embedding.data().len(), "Audio embedding generated");
+
+    Ok(MsgPack(AudioEmbedResponse {
+        embedding: embedding.into_data(),
+        duration_s,
+    }))
+}
+
+/// Fallback handlers when inference feature is disabled
+#[cfg(not(feature = "inference"))]
+pub async fn text_embed(State(_state): State<AppState>) -> Result<(), AppError> {
+    Err(AppError::Internal(
+        "Inference feature not enabled".to_string(),
+    ))
+}
+
+#[cfg(not(feature = "inference"))]
+pub async fn audio_embed(State(_state): State<AppState>) -> Result<(), AppError> {
+    Err(AppError::Internal(
+        "Inference feature not enabled".to_string(),
+    ))
+}

--- a/src/server/embed.rs
+++ b/src/server/embed.rs
@@ -94,6 +94,18 @@ pub async fn audio_embed(
     // Convert request to AudioData
     let audio_data: AudioData = req.into();
 
+    // Validate audio parameters to avoid division by zero
+    if audio_data.channels == 0 {
+        return Err(AppError::BadRequest(
+            "Channel count must be at least 1".to_string(),
+        ));
+    }
+    if audio_data.sample_rate == 0 {
+        return Err(AppError::BadRequest(
+            "Sample rate must be greater than 0".to_string(),
+        ));
+    }
+
     // Calculate duration for response
     let samples_per_channel = match audio_data.format {
         crate::inference::AudioFormat::PcmF32Le => audio_data.data.len() / 4,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,5 +1,6 @@
 //! HTTP server setup and routing.
 
+mod embed;
 mod extractors;
 mod routes;
 mod tracks;
@@ -84,7 +85,10 @@ pub fn create_router(state: AppState) -> Router {
     let api_routes = Router::new()
         .route("/health", get(routes::health))
         .route("/config", get(routes::config))
-        // Track embedding endpoints
+        // Embedding generation endpoints
+        .route("/embed/text", post(embed::text_embed))
+        .route("/embed/audio", post(embed::audio_embed))
+        // Track storage endpoints
         .route("/tracks/upsert", post(tracks::upsert))
         .route("/tracks/search", post(tracks::search))
         .route(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -91,6 +91,7 @@ pub fn create_router(state: AppState) -> Router {
         // Track storage endpoints
         .route("/tracks/upsert", post(tracks::upsert))
         .route("/tracks/search", post(tracks::search))
+        .route("/tracks/embed-text", post(tracks::embed_text_and_store))
         .route(
             "/tracks/:id",
             get(tracks::get_track).delete(tracks::delete_track),

--- a/src/server/tracks.rs
+++ b/src/server/tracks.rs
@@ -4,6 +4,8 @@ use axum::extract::{Path, Query, State};
 use serde::Deserialize;
 
 use crate::error::AppError;
+
+#[cfg(feature = "storage")]
 use crate::types::{
     DeleteRequest, DeleteResponse, GetTrackResponse, SearchRequest, SearchResponse,
     UpsertRequest, UpsertResponse,
@@ -291,20 +293,14 @@ pub async fn delete_track(
 
 /// Fallback handlers when storage feature is disabled
 #[cfg(not(feature = "storage"))]
-pub async fn upsert(
-    State(_state): State<AppState>,
-    MsgPackExtractor(_req): MsgPackExtractor<UpsertRequest>,
-) -> Result<MsgPack<UpsertResponse>, AppError> {
+pub async fn upsert(State(_state): State<AppState>) -> Result<(), AppError> {
     Err(AppError::Internal(
         "Storage feature not enabled".to_string(),
     ))
 }
 
 #[cfg(not(feature = "storage"))]
-pub async fn search(
-    State(_state): State<AppState>,
-    MsgPackExtractor(_req): MsgPackExtractor<SearchRequest>,
-) -> Result<MsgPack<SearchResponse>, AppError> {
+pub async fn search(State(_state): State<AppState>) -> Result<(), AppError> {
     Err(AppError::Internal(
         "Storage feature not enabled".to_string(),
     ))
@@ -315,7 +311,7 @@ pub async fn get_track(
     State(_state): State<AppState>,
     Path(_track_id): Path<String>,
     Query(_query): Query<GetTrackQuery>,
-) -> Result<MsgPack<GetTrackResponse>, AppError> {
+) -> Result<(), AppError> {
     Err(AppError::Internal(
         "Storage feature not enabled".to_string(),
     ))
@@ -325,8 +321,7 @@ pub async fn get_track(
 pub async fn delete_track(
     State(_state): State<AppState>,
     Path(_track_id): Path<String>,
-    MsgPackExtractor(_req): MsgPackExtractor<DeleteRequest>,
-) -> Result<MsgPack<DeleteResponse>, AppError> {
+) -> Result<(), AppError> {
     Err(AppError::Internal(
         "Storage feature not enabled".to_string(),
     ))

--- a/src/server/tracks.rs
+++ b/src/server/tracks.rs
@@ -11,12 +11,21 @@ use crate::types::{
     UpsertRequest, UpsertResponse,
 };
 
+#[cfg(all(feature = "inference", feature = "storage"))]
+use crate::types::{EmbedTextAndStoreRequest, EmbedTextAndStoreResponse};
+
 use super::extractors::MsgPackExtractor;
 use super::routes::MsgPack;
 use super::AppState;
 
 #[cfg(feature = "storage")]
 use crate::storage::{VectorStorage, AUDIO_COLLECTION, EMBEDDING_DIM, TEXT_COLLECTION};
+
+#[cfg(all(feature = "inference", feature = "storage"))]
+use crate::inference::{format_track_metadata, TextTrackMetadata};
+
+#[cfg(all(feature = "inference", feature = "storage"))]
+use crate::storage::TrackMetadata;
 
 #[cfg(feature = "storage")]
 use tracing::{debug, error, info};
@@ -289,6 +298,96 @@ pub async fn delete_track(
         text_deleted,
         audio_deleted,
     }))
+}
+
+/// POST /api/v1/tracks/embed-text
+///
+/// Generate text embedding from metadata and store it in one operation.
+/// Requires both inference and storage features.
+#[cfg(all(feature = "inference", feature = "storage"))]
+pub async fn embed_text_and_store(
+    State(state): State<AppState>,
+    MsgPackExtractor(req): MsgPackExtractor<EmbedTextAndStoreRequest>,
+) -> Result<MsgPack<EmbedTextAndStoreResponse>, AppError> {
+    let model = state
+        .model
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Model not loaded".to_string()))?;
+
+    let storage = state
+        .storage
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Storage not configured".to_string()))?;
+
+    info!(track_id = %req.track_id, "Generating and storing text embedding");
+
+    // Format metadata into text for embedding
+    let track_meta = TextTrackMetadata {
+        name: req.metadata.name.clone(),
+        artists: req.metadata.artists.clone(),
+        album: req.metadata.album.clone(),
+        genres: req.metadata.genres.clone(),
+        mood: None,
+    };
+    let text = format_track_metadata(&track_meta);
+
+    // Generate embedding using the model
+    let embedding = tokio::task::spawn_blocking({
+        let model = model.clone();
+        let text = text.clone();
+        move || model.text_embedding(&text)
+    })
+    .await
+    .map_err(|e| {
+        error!(error = %e, "Text embedding task panicked");
+        AppError::Internal(e.to_string())
+    })?
+    .map_err(|e| {
+        error!(error = %e, "Text embedding failed");
+        AppError::from(e)
+    })?;
+
+    debug!(embedding_dim = embedding.data().len(), "Text embedding generated");
+
+    // Build storage metadata
+    let storage_metadata = TrackMetadata::new(req.track_id.clone(), req.metadata.name)
+        .with_artists(req.metadata.artists)
+        .with_genres(req.metadata.genres);
+    let storage_metadata = if let Some(album) = req.metadata.album {
+        storage_metadata.with_album(album)
+    } else {
+        storage_metadata
+    };
+
+    // Store the embedding
+    storage
+        .upsert(
+            TEXT_COLLECTION,
+            &req.track_id,
+            embedding.data(),
+            storage_metadata,
+        )
+        .await
+        .map_err(|e| {
+            error!(error = %e, "Failed to store text embedding");
+            AppError::Internal(e.to_string())
+        })?;
+
+    debug!(track_id = %req.track_id, "Text embedding stored");
+
+    Ok(MsgPack(EmbedTextAndStoreResponse {
+        track_id: req.track_id,
+        stored: true,
+        text,
+    }))
+}
+
+/// Fallback handler when inference or storage feature is disabled
+#[cfg(not(all(feature = "inference", feature = "storage")))]
+pub async fn embed_text_and_store(State(_state): State<AppState>) -> Result<(), AppError> {
+    Err(AppError::Internal(
+        "Both inference and storage features must be enabled".to_string(),
+    ))
 }
 
 /// Fallback handlers when storage feature is disabled

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -322,3 +322,46 @@ pub struct AudioEmbedResponse {
     /// Duration of audio in seconds
     pub duration_s: f32,
 }
+
+// ============================================================================
+// Combined embedding + storage types (requires both inference and storage)
+// ============================================================================
+
+/// Request to generate text embedding from metadata and store it
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedTextAndStoreRequest {
+    /// Track ID (Music Assistant item_id)
+    pub track_id: String,
+    /// Track metadata for embedding generation and storage
+    pub metadata: EmbedTextAndStoreMetadata,
+}
+
+/// Track metadata for combined embed + store operation
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedTextAndStoreMetadata {
+    /// Track name
+    pub name: String,
+    /// Artist names
+    #[serde(default)]
+    pub artists: Vec<String>,
+    /// Album name
+    #[serde(default)]
+    pub album: Option<String>,
+    /// Genre tags
+    #[serde(default)]
+    pub genres: Vec<String>,
+}
+
+/// Response from combined embed + store operation
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EmbedTextAndStoreResponse {
+    /// Track ID that was processed
+    pub track_id: String,
+    /// Whether the embedding was stored successfully
+    pub stored: bool,
+    /// The text that was embedded (for verification)
+    pub text: String,
+}

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -2,9 +2,14 @@
 
 use serde::{Deserialize, Serialize};
 
+#[cfg(feature = "storage")]
 use crate::storage::{SearchFilter, SearchResult, TrackMetadata};
 
+#[cfg(feature = "inference")]
+use crate::inference::{AudioData, AudioFormat};
+
 /// Request to upsert track embedding(s)
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpsertRequest {
     /// Track ID (Music Assistant item_id)
@@ -20,6 +25,7 @@ pub struct UpsertRequest {
 }
 
 /// Input metadata for upsert operations
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TrackMetadataInput {
     /// Track name
@@ -35,6 +41,7 @@ pub struct TrackMetadataInput {
     pub genres: Vec<String>,
 }
 
+#[cfg(feature = "storage")]
 impl TrackMetadataInput {
     /// Convert to storage TrackMetadata
     pub fn into_storage(self, track_id: String) -> TrackMetadata {
@@ -51,6 +58,7 @@ impl TrackMetadataInput {
 }
 
 /// Response from upsert operation
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpsertResponse {
     /// Track ID that was upserted
@@ -62,6 +70,7 @@ pub struct UpsertResponse {
 }
 
 /// Request to search for similar tracks
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchRequest {
     /// Query embedding (512-dimensional)
@@ -76,11 +85,13 @@ pub struct SearchRequest {
     pub filter: Option<SearchFilterInput>,
 }
 
+#[cfg(feature = "storage")]
 fn default_limit() -> usize {
     10
 }
 
 /// Input filter for search operations
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchFilterInput {
     /// Filter by artist names (any match)
@@ -97,6 +108,7 @@ pub struct SearchFilterInput {
     pub exclude_ids: Option<Vec<String>>,
 }
 
+#[cfg(feature = "storage")]
 impl From<SearchFilterInput> for SearchFilter {
     fn from(input: SearchFilterInput) -> Self {
         let mut filter = SearchFilter::new();
@@ -119,6 +131,7 @@ impl From<SearchFilterInput> for SearchFilter {
 }
 
 /// Response from search operation
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResponse {
     /// Search results sorted by similarity
@@ -128,6 +141,7 @@ pub struct SearchResponse {
 }
 
 /// Request to delete a track's embeddings
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteRequest {
     /// Delete from text collection
@@ -138,10 +152,12 @@ pub struct DeleteRequest {
     pub audio: bool,
 }
 
+#[cfg(feature = "storage")]
 fn default_true() -> bool {
     true
 }
 
+#[cfg(feature = "storage")]
 impl Default for DeleteRequest {
     fn default() -> Self {
         Self {
@@ -152,6 +168,7 @@ impl Default for DeleteRequest {
 }
 
 /// Response from delete operation
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DeleteResponse {
     /// Track ID that was deleted
@@ -163,6 +180,7 @@ pub struct DeleteResponse {
 }
 
 /// Response for get track operation
+#[cfg(feature = "storage")]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTrackResponse {
     /// Track ID
@@ -181,7 +199,7 @@ pub struct GetTrackResponse {
     pub audio_embedding: Option<Vec<f32>>,
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "storage"))]
 mod tests {
     use super::*;
 
@@ -223,4 +241,84 @@ mod tests {
         assert!(filter.album.is_some());
         assert!(filter.exclude_ids.is_some());
     }
+}
+
+// ============================================================================
+// Embedding generation types (inference feature)
+// ============================================================================
+
+/// Request to generate text embedding
+#[cfg(feature = "inference")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextEmbedRequest {
+    /// Raw text to embed (optional if metadata provided)
+    #[serde(default)]
+    pub text: Option<String>,
+    /// Track metadata to format and embed (optional if text provided)
+    #[serde(default)]
+    pub metadata: Option<TextEmbedMetadata>,
+}
+
+/// Track metadata for text embedding generation
+#[cfg(feature = "inference")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextEmbedMetadata {
+    /// Track name
+    pub name: String,
+    /// Artist names
+    #[serde(default)]
+    pub artists: Vec<String>,
+    /// Album name
+    #[serde(default)]
+    pub album: Option<String>,
+    /// Genre tags
+    #[serde(default)]
+    pub genres: Vec<String>,
+}
+
+/// Response from text embedding generation
+#[cfg(feature = "inference")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TextEmbedResponse {
+    /// Generated embedding (512-dimensional)
+    pub embedding: Vec<f32>,
+    /// Text that was embedded (for verification)
+    pub text: String,
+}
+
+/// Request to generate audio embedding
+#[cfg(feature = "inference")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioEmbedRequest {
+    /// Audio format
+    pub format: AudioFormat,
+    /// Sample rate in Hz
+    pub sample_rate: u32,
+    /// Number of channels (1 = mono, 2 = stereo)
+    pub channels: u8,
+    /// Raw PCM bytes
+    #[serde(with = "serde_bytes")]
+    pub data: Vec<u8>,
+}
+
+#[cfg(feature = "inference")]
+impl From<AudioEmbedRequest> for AudioData {
+    fn from(req: AudioEmbedRequest) -> Self {
+        AudioData {
+            format: req.format,
+            sample_rate: req.sample_rate,
+            channels: req.channels,
+            data: req.data,
+        }
+    }
+}
+
+/// Response from audio embedding generation
+#[cfg(feature = "inference")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AudioEmbedResponse {
+    /// Generated embedding (512-dimensional)
+    pub embedding: Vec<f32>,
+    /// Duration of audio in seconds
+    pub duration_s: f32,
 }


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/embed/text` endpoint for text embedding generation
- Add `POST /api/v1/embed/audio` endpoint for audio embedding generation
- Add `POST /api/v1/tracks/embed-text` combined endpoint (generate + store in one call)
- Add request/response types with proper cfg gating for feature flags
- Add `serde_bytes` crate for efficient binary serialization
- Add audio parameter validation (channels, sample_rate) before duration calculation

## Test plan
- [x] Run `cargo build --features storage` - compiles successfully
- [x] Run `cargo build` (no features) - compiles successfully
- [x] Run `cargo clippy --features storage` - no warnings
- [x] Run `cargo test --features storage` - 7 tests pass
- [ ] Integration test with loaded CLAP model