### PR TITLE
feat: Phase 6 - Batch operations

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -95,7 +95,10 @@ pub fn create_router(state: AppState) -> Router {
         .route(
             "/tracks/:id",
             get(tracks::get_track).delete(tracks::delete_track),
-        );
+        )
+        // Batch operations
+        .route("/tracks/batch-upsert", post(tracks::batch_upsert))
+        .route("/tracks/batch-embed-text", post(tracks::batch_embed_text));
 
     Router::new()
         .nest("/api/v1", api_routes)

--- a/src/types/api.rs
+++ b/src/types/api.rs
@@ -365,3 +365,88 @@ pub struct EmbedTextAndStoreResponse {
     /// The text that was embedded (for verification)
     pub text: String,
 }
+
+// ============================================================================
+// Batch operation types (storage feature)
+// ============================================================================
+
+/// Request to batch upsert multiple track embeddings
+#[cfg(feature = "storage")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpsertRequest {
+    /// List of tracks to upsert
+    pub tracks: Vec<UpsertRequest>,
+}
+
+/// Response from batch upsert operation
+#[cfg(feature = "storage")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpsertResponse {
+    /// Results for each track
+    pub results: Vec<BatchUpsertResult>,
+    /// Total number of tracks processed
+    pub total: usize,
+    /// Number of successful upserts
+    pub succeeded: usize,
+    /// Number of failed upserts
+    pub failed: usize,
+}
+
+/// Result for a single track in batch upsert
+#[cfg(feature = "storage")]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchUpsertResult {
+    /// Track ID
+    pub track_id: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+    /// Error message if failed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// Whether text embedding was stored
+    pub text_stored: bool,
+    /// Whether audio embedding was stored
+    pub audio_stored: bool,
+}
+
+// ============================================================================
+// Batch embed + store types (requires both inference and storage)
+// ============================================================================
+
+/// Request to batch generate text embeddings and store them
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEmbedTextRequest {
+    /// List of tracks to embed and store
+    pub tracks: Vec<EmbedTextAndStoreRequest>,
+}
+
+/// Response from batch embed text operation
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEmbedTextResponse {
+    /// Results for each track
+    pub results: Vec<BatchEmbedTextResult>,
+    /// Total number of tracks processed
+    pub total: usize,
+    /// Number of successful operations
+    pub succeeded: usize,
+    /// Number of failed operations
+    pub failed: usize,
+}
+
+/// Result for a single track in batch embed text
+#[cfg(all(feature = "inference", feature = "storage"))]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchEmbedTextResult {
+    /// Track ID
+    pub track_id: String,
+    /// Whether the operation succeeded
+    pub success: bool,
+    /// Error message if failed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    /// The text that was embedded (for verification)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}


### PR DESCRIPTION
## Summary
- Add `POST /api/v1/tracks/batch-upsert` for bulk upserting track embeddings
- Add `POST /api/v1/tracks/batch-embed-text` for bulk text embedding generation and storage
- Each endpoint returns per-track results with success/failure status and error messages
- Supports partial success scenarios (some tracks succeed, others fail)

## API

### POST /api/v1/tracks/batch-upsert
```json
{
  "tracks": [
    {
      "track_id": "track_1",
      "metadata": { "name": "Song 1", "artists": ["Artist"] },
      "text_embedding": [0.1, ...],
      "audio_embedding": null
    }
  ]
}
```

### POST /api/v1/tracks/batch-embed-text
```json
{
  "tracks": [
    {
      "track_id": "track_1",
      "metadata": { "name": "Song 1", "artists": ["Artist"], "genres": ["rock"] }
    }
  ]
}
```

## Test plan
- [x] Run `cargo build --features storage` - compiles successfully
- [x] Run `cargo build` (no features) - compiles successfully
- [x] Run `cargo test --features storage` - 7 tests pass
- [ ] Integration test with loaded model and Qdrant