### PR TITLE
feat: CLI improvements with clap and Qdrant Cloud support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ rmp-serde = "1"
 # Configuration
 config = "0.14"
 
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
 # Error handling
 thiserror = "1"
 anyhow = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -79,9 +79,13 @@ fn default_hop_size() -> f32 {
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct StorageConfig {
-    /// Qdrant server URL
+    /// Qdrant server URL (e.g., http://localhost:6334 or https://xxx.cloud.qdrant.io:6333)
     #[serde(default = "default_qdrant_url")]
     pub url: String,
+
+    /// API key for Qdrant Cloud or authenticated instances
+    #[serde(default)]
+    pub api_key: Option<String>,
 
     /// Prefix for collection names (useful for multi-tenant setups)
     #[serde(default)]
@@ -96,6 +100,7 @@ impl Default for StorageConfig {
     fn default() -> Self {
         Self {
             url: default_qdrant_url(),
+            api_key: None,
             collection_prefix: None,
             enabled: default_storage_enabled(),
         }

--- a/src/storage/qdrant.rs
+++ b/src/storage/qdrant.rs
@@ -34,10 +34,20 @@ impl std::fmt::Debug for QdrantStorage {
 
 impl QdrantStorage {
     /// Create a new Qdrant storage client
-    pub async fn new(url: &str, collection_prefix: Option<String>) -> Result<Self, StorageError> {
-        info!(%url, "Connecting to Qdrant");
+    pub async fn new(
+        url: &str,
+        api_key: Option<String>,
+        collection_prefix: Option<String>,
+    ) -> Result<Self, StorageError> {
+        info!(%url, has_api_key = api_key.is_some(), "Connecting to Qdrant");
 
-        let client = Qdrant::from_url(url)
+        let mut builder = Qdrant::from_url(url);
+
+        if let Some(key) = api_key {
+            builder = builder.api_key(key);
+        }
+
+        let client = builder
             .build()
             .map_err(|e| StorageError::ConnectionFailed(e.to_string()))?;
 


### PR DESCRIPTION
## Summary
- Add `clap` for CLI argument parsing with derive macros
- Add `--qdrant-api-key` for Qdrant Cloud authentication
- Add `--no-storage` flag to disable storage
- Add `-v`/`-q` flags for verbosity control
- Add startup banner with version info
- CLI args override environment variables

## Usage

```bash
# Local Qdrant
insight-sidecar --qdrant-url http://localhost:6334

# Qdrant Cloud
insight-sidecar \
  --qdrant-url https://xxx.cloud.qdrant.io:6333 \
  --qdrant-api-key your-api-key

# Inference only (no storage)
insight-sidecar --no-storage

# Debug logging
insight-sidecar -v

# Custom port
insight-sidecar -p 9000
```

## CLI Help
```
Options:
  -p, --port <PORT>          Server port to listen on
      --host <HOST>          Server host to bind to
      --qdrant-url <URL>     Qdrant server URL
      --qdrant-api-key <KEY> API key for Qdrant Cloud
      --collection-prefix    Collection name prefix
      --no-storage           Disable vector storage
      --model <MODEL>        CLAP model to use
      --cuda                 Enable CUDA acceleration
  -v, --verbose              Debug/trace logging
  -q, --quiet                Warnings only
```

## Test plan
- [x] Run `cargo build --features storage` - compiles
- [x] Run `cargo test --features storage` - 7 tests pass
- [x] Run `cargo run --features storage -- --help` - shows CLI options