### PR TITLE
feat: add GitHub Actions CI/CD workflows and Dockerfiles

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,15 @@
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native"]
+# Cross-compilation configuration for insight-sidecar
 
+# Linux ARM64 (aarch64) - for cross-compilation
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+# Linux x86_64
+[target.x86_64-unknown-linux-gnu]
+# Note: target-cpu=native is only suitable for local builds
+# CI builds use default CPU features for broader compatibility
+
+# Build settings
 [build]
 rustflags = [
     "-W", "clippy::all",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,110 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+    paths:
+      - "sidecar/**"
+      - ".github/workflows/ci.yml"
+  pull_request:
+    branches: [main, dev]
+    paths:
+      - "sidecar/**"
+      - ".github/workflows/ci.yml"
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+defaults:
+  run:
+    working-directory: sidecar
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+        with:
+          components: rustfmt, clippy
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sidecar/target
+          key: ${{ runner.os }}-cargo-lint-${{ hashFiles('sidecar/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-lint-
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+      - name: Run clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sidecar/target
+          key: ${{ runner.os }}-cargo-test-${{ hashFiles('sidecar/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-test-
+
+      - name: Run tests
+        run: cargo test --all-features
+
+  build-check:
+    name: Build Check
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        features:
+          - ""  # No features (minimal)
+          - "storage,storage-file,audio,watcher"  # CPU full
+          - "cuda,storage,storage-file,audio,watcher"  # CUDA
+          - "rocm,storage,storage-file,audio,watcher"  # ROCm
+          - "openvino,storage,storage-file,audio,watcher"  # OpenVINO
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sidecar/target
+          key: ${{ runner.os }}-cargo-build-${{ matrix.features }}-${{ hashFiles('sidecar/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-build-${{ matrix.features }}-
+
+      - name: Build with features (${{ matrix.features || 'none' }})
+        run: |
+          if [ -z "${{ matrix.features }}" ]; then
+            cargo build --release
+          else
+            cargo build --release --features "${{ matrix.features }}"
+          fi

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,234 @@
+name: Docker
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g., v0.1.0)"
+        required: true
+        type: string
+      push:
+        description: "Push images to registry"
+        required: false
+        type: boolean
+        default: true
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository_owner }}/insight-sidecar
+
+jobs:
+  build-cpu:
+    name: Build CPU Image (Multi-arch)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "version_short=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=latest
+            type=raw,value=cpu
+            type=semver,pattern={{version}},value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ steps.version.outputs.version }}
+
+      - name: Build and push CPU image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sidecar
+          file: ./sidecar/docker/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name == 'push' || github.event.inputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            FEATURES=storage,storage-file,audio,watcher
+            BASE_IMAGE=debian:bookworm-slim
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-cuda:
+    name: Build CUDA Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=cuda
+            type=semver,pattern={{version}}-cuda,value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}}-cuda,value=${{ steps.version.outputs.version }}
+
+      - name: Build and push CUDA image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sidecar
+          file: ./sidecar/docker/Dockerfile.cuda
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' || github.event.inputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-rocm:
+    name: Build ROCm Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=rocm
+            type=semver,pattern={{version}}-rocm,value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}}-rocm,value=${{ steps.version.outputs.version }}
+
+      - name: Build and push ROCm image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sidecar
+          file: ./sidecar/docker/Dockerfile.rocm
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' || github.event.inputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-openvino:
+    name: Build OpenVINO Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            VERSION="${{ github.event.inputs.tag }}"
+          else
+            VERSION="${GITHUB_REF#refs/tags/}"
+          fi
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=openvino
+            type=semver,pattern={{version}}-openvino,value=${{ steps.version.outputs.version }}
+            type=semver,pattern={{major}}.{{minor}}-openvino,value=${{ steps.version.outputs.version }}
+
+      - name: Build and push OpenVINO image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./sidecar
+          file: ./sidecar/docker/Dockerfile.openvino
+          platforms: linux/amd64
+          push: ${{ github.event_name == 'push' || github.event.inputs.push == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,249 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g., v0.1.0)"
+        required: true
+        type: string
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  BINARY_NAME: insight-sidecar
+
+defaults:
+  run:
+    working-directory: sidecar
+
+jobs:
+  build:
+    name: Build ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Linux x86_64
+          - name: linux-x86_64-cpu
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          - name: linux-x86_64-cuda
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: cuda,storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          - name: linux-x86_64-rocm
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: rocm,storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          - name: linux-x86_64-openvino
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            features: openvino,storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          # Linux aarch64
+          - name: linux-aarch64-cpu
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            features: storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: true
+
+          # Windows x86_64
+          - name: windows-x86_64-cpu
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: storage,storage-file,audio,watcher
+            ext: zip
+            cross: false
+
+          - name: windows-x86_64-cuda
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: cuda,storage,storage-file,audio,watcher
+            ext: zip
+            cross: false
+
+          - name: windows-x86_64-directml
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: directml,storage,storage-file,audio,watcher
+            ext: zip
+            cross: false
+
+          - name: windows-x86_64-openvino
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            features: openvino,storage,storage-file,audio,watcher
+            ext: zip
+            cross: false
+
+          # macOS x86_64
+          - name: macos-x86_64-cpu
+            os: macos-13
+            target: x86_64-apple-darwin
+            features: storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          - name: macos-x86_64-coreml
+            os: macos-13
+            target: x86_64-apple-darwin
+            features: coreml,storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          # macOS aarch64 (Apple Silicon)
+          - name: macos-aarch64-cpu
+            os: macos-latest
+            target: aarch64-apple-darwin
+            features: storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+          - name: macos-aarch64-coreml
+            os: macos-latest
+            target: aarch64-apple-darwin
+            features: coreml,storage,storage-file,audio,watcher
+            ext: tar.gz
+            cross: false
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-action@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux aarch64)
+        if: matrix.cross && matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            sidecar/target
+          key: ${{ runner.os }}-${{ matrix.target }}-cargo-release-${{ hashFiles('sidecar/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.target }}-cargo-release-
+
+      - name: Build release binary
+        shell: bash
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
+        run: |
+          cargo build --release --target ${{ matrix.target }} --features "${{ matrix.features }}"
+
+      - name: Strip binary (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          if [ "${{ matrix.cross }}" = "true" ] && [ "${{ matrix.target }}" = "aarch64-unknown-linux-gnu" ]; then
+            aarch64-linux-gnu-strip target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
+          else
+            strip target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}
+          fi
+
+      - name: Create archive (Unix)
+        if: runner.os != 'Windows'
+        shell: bash
+        run: |
+          ARCHIVE_NAME="${{ env.BINARY_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.name }}.${{ matrix.ext }}"
+          cd target/${{ matrix.target }}/release
+          tar -czvf "../../../${ARCHIVE_NAME}" ${{ env.BINARY_NAME }}
+          cd ../../..
+          echo "ARCHIVE_NAME=${ARCHIVE_NAME}" >> $GITHUB_ENV
+
+      - name: Create archive (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $archiveName = "${{ env.BINARY_NAME }}-${{ steps.version.outputs.version }}-${{ matrix.name }}.${{ matrix.ext }}"
+          Compress-Archive -Path "target/${{ matrix.target }}/release/${{ env.BINARY_NAME }}.exe" -DestinationPath $archiveName
+          echo "ARCHIVE_NAME=$archiveName" >> $env:GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.name }}
+          path: sidecar/${{ env.ARCHIVE_NAME }}
+          if-no-files-found: error
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.tag }}" ]; then
+            echo "version=${{ github.event.inputs.tag }}" >> $GITHUB_OUTPUT
+          else
+            echo "version=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release
+          find artifacts -type f \( -name "*.tar.gz" -o -name "*.zip" \) -exec mv {} release/ \;
+
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum * > SHA256SUMS.txt
+          cat SHA256SUMS.txt
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.version }}
+          name: Release ${{ steps.version.outputs.version }}
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}
+          generate_release_notes: true
+          files: |
+            release/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,107 @@
+# Multi-stage Dockerfile for insight-sidecar (CPU version)
+# Supports multi-arch builds (amd64, arm64)
+
+ARG RUST_VERSION=1.83
+ARG BASE_IMAGE=debian:bookworm-slim
+ARG FEATURES=storage,storage-file,audio,watcher
+
+# =============================================================================
+# Builder stage
+# =============================================================================
+FROM --platform=$BUILDPLATFORM rust:${RUST_VERSION}-bookworm AS builder
+
+ARG TARGETPLATFORM
+ARG BUILDPLATFORM
+ARG FEATURES
+
+# Install cross-compilation tools for ARM64 if needed
+RUN case "$TARGETPLATFORM" in \
+    "linux/arm64") \
+        apt-get update && apt-get install -y \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu \
+            libc6-dev-arm64-cross \
+        && rm -rf /var/lib/apt/lists/* \
+        && rustup target add aarch64-unknown-linux-gnu \
+        ;; \
+    esac
+
+WORKDIR /build
+
+# Copy manifests first for better caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create dummy source to cache dependencies
+RUN mkdir -p src && \
+    echo 'fn main() { println!("dummy"); }' > src/main.rs
+
+# Pre-build dependencies
+RUN case "$TARGETPLATFORM" in \
+    "linux/arm64") \
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc && \
+        cargo build --release --target aarch64-unknown-linux-gnu --features "$FEATURES" || true \
+        ;; \
+    *) \
+        cargo build --release --features "$FEATURES" || true \
+        ;; \
+    esac
+
+# Copy actual source code
+COPY src ./src
+
+# Build the actual binary
+RUN case "$TARGETPLATFORM" in \
+    "linux/arm64") \
+        export CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc && \
+        cargo build --release --target aarch64-unknown-linux-gnu --features "$FEATURES" && \
+        aarch64-linux-gnu-strip /build/target/aarch64-unknown-linux-gnu/release/insight-sidecar && \
+        cp /build/target/aarch64-unknown-linux-gnu/release/insight-sidecar /build/insight-sidecar \
+        ;; \
+    *) \
+        cargo build --release --features "$FEATURES" && \
+        strip /build/target/release/insight-sidecar && \
+        cp /build/target/release/insight-sidecar /build/insight-sidecar \
+        ;; \
+    esac
+
+# =============================================================================
+# Runtime stage
+# =============================================================================
+FROM ${BASE_IMAGE}
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r sidecar && useradd -r -g sidecar sidecar
+
+# Copy binary from builder
+COPY --from=builder /build/insight-sidecar /usr/local/bin/insight-sidecar
+
+# Create data directory
+RUN mkdir -p /data && chown -R sidecar:sidecar /data
+
+# Switch to non-root user
+USER sidecar
+
+# Set default environment variables
+ENV INSIGHT_SERVER__HOST=0.0.0.0
+ENV INSIGHT_SERVER__PORT=8096
+ENV INSIGHT_STORAGE__MODE=file
+ENV INSIGHT_STORAGE__DATA_DIR=/data
+
+# Expose the default port
+EXPOSE 8096
+
+# Set volume for persistent data
+VOLUME ["/data"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8096/health || exit 1
+
+# Run the sidecar
+ENTRYPOINT ["insight-sidecar"]

--- a/docker/Dockerfile.cuda
+++ b/docker/Dockerfile.cuda
@@ -1,0 +1,80 @@
+# Dockerfile for insight-sidecar with NVIDIA CUDA support
+# Single arch: linux/amd64 only
+
+ARG RUST_VERSION=1.83
+ARG CUDA_VERSION=12.6.3
+ARG UBUNTU_VERSION=24.04
+
+# =============================================================================
+# Builder stage
+# =============================================================================
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+ARG FEATURES=cuda,storage,storage-file,audio,watcher
+
+WORKDIR /build
+
+# Copy manifests first for better caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create dummy source to cache dependencies
+RUN mkdir -p src && \
+    echo 'fn main() { println!("dummy"); }' > src/main.rs
+
+# Pre-build dependencies
+RUN cargo build --release --features "$FEATURES" || true
+
+# Copy actual source code
+COPY src ./src
+
+# Build the actual binary
+RUN cargo build --release --features "$FEATURES" && \
+    strip /build/target/release/insight-sidecar
+
+# =============================================================================
+# Runtime stage
+# =============================================================================
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-ubuntu${UBUNTU_VERSION}
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r sidecar && useradd -r -g sidecar sidecar
+
+# Copy binary from builder
+COPY --from=builder /build/target/release/insight-sidecar /usr/local/bin/insight-sidecar
+
+# Create data directory
+RUN mkdir -p /data && chown -R sidecar:sidecar /data
+
+# Switch to non-root user
+USER sidecar
+
+# Set default environment variables
+ENV INSIGHT_SERVER__HOST=0.0.0.0
+ENV INSIGHT_SERVER__PORT=8096
+ENV INSIGHT_STORAGE__MODE=file
+ENV INSIGHT_STORAGE__DATA_DIR=/data
+ENV INSIGHT_MODEL__ENABLE_CUDA=true
+
+# NVIDIA runtime settings
+ENV NVIDIA_VISIBLE_DEVICES=all
+ENV NVIDIA_DRIVER_CAPABILITIES=compute,utility
+
+# Expose the default port
+EXPOSE 8096
+
+# Set volume for persistent data
+VOLUME ["/data"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8096/health || exit 1
+
+# Run the sidecar
+ENTRYPOINT ["insight-sidecar"]

--- a/docker/Dockerfile.openvino
+++ b/docker/Dockerfile.openvino
@@ -1,0 +1,77 @@
+# Dockerfile for insight-sidecar with Intel OpenVINO support
+# Single arch: linux/amd64 only
+
+ARG RUST_VERSION=1.83
+ARG OPENVINO_VERSION=2024.5.0
+
+# =============================================================================
+# Builder stage
+# =============================================================================
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+ARG FEATURES=openvino,storage,storage-file,audio,watcher
+
+WORKDIR /build
+
+# Copy manifests first for better caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create dummy source to cache dependencies
+RUN mkdir -p src && \
+    echo 'fn main() { println!("dummy"); }' > src/main.rs
+
+# Pre-build dependencies
+RUN cargo build --release --features "$FEATURES" || true
+
+# Copy actual source code
+COPY src ./src
+
+# Build the actual binary
+RUN cargo build --release --features "$FEATURES" && \
+    strip /build/target/release/insight-sidecar
+
+# =============================================================================
+# Runtime stage
+# =============================================================================
+FROM openvino/ubuntu24_runtime:${OPENVINO_VERSION}
+
+USER root
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user
+RUN groupadd -r sidecar && useradd -r -g sidecar sidecar
+
+# Copy binary from builder
+COPY --from=builder /build/target/release/insight-sidecar /usr/local/bin/insight-sidecar
+
+# Create data directory
+RUN mkdir -p /data && chown -R sidecar:sidecar /data
+
+# Switch to non-root user
+USER sidecar
+
+# Set default environment variables
+ENV INSIGHT_SERVER__HOST=0.0.0.0
+ENV INSIGHT_SERVER__PORT=8096
+ENV INSIGHT_STORAGE__MODE=file
+ENV INSIGHT_STORAGE__DATA_DIR=/data
+ENV INSIGHT_MODEL__ENABLE_OPENVINO=true
+
+# Expose the default port
+EXPOSE 8096
+
+# Set volume for persistent data
+VOLUME ["/data"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8096/health || exit 1
+
+# Run the sidecar
+ENTRYPOINT ["insight-sidecar"]

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -1,0 +1,78 @@
+# Dockerfile for insight-sidecar with AMD ROCm support
+# Single arch: linux/amd64 only
+
+ARG RUST_VERSION=1.83
+ARG ROCM_VERSION=6.2
+
+# =============================================================================
+# Builder stage
+# =============================================================================
+FROM rust:${RUST_VERSION}-bookworm AS builder
+
+ARG FEATURES=rocm,storage,storage-file,audio,watcher
+
+WORKDIR /build
+
+# Copy manifests first for better caching
+COPY Cargo.toml Cargo.lock ./
+
+# Create dummy source to cache dependencies
+RUN mkdir -p src && \
+    echo 'fn main() { println!("dummy"); }' > src/main.rs
+
+# Pre-build dependencies
+RUN cargo build --release --features "$FEATURES" || true
+
+# Copy actual source code
+COPY src ./src
+
+# Build the actual binary
+RUN cargo build --release --features "$FEATURES" && \
+    strip /build/target/release/insight-sidecar
+
+# =============================================================================
+# Runtime stage
+# =============================================================================
+FROM rocm/dev-ubuntu-24.04:${ROCM_VERSION}
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    libssl3 \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user (use video group for ROCm access)
+RUN groupadd -r sidecar && useradd -r -g sidecar -G video,render sidecar
+
+# Copy binary from builder
+COPY --from=builder /build/target/release/insight-sidecar /usr/local/bin/insight-sidecar
+
+# Create data directory
+RUN mkdir -p /data && chown -R sidecar:sidecar /data
+
+# Switch to non-root user
+USER sidecar
+
+# Set default environment variables
+ENV INSIGHT_SERVER__HOST=0.0.0.0
+ENV INSIGHT_SERVER__PORT=8096
+ENV INSIGHT_STORAGE__MODE=file
+ENV INSIGHT_STORAGE__DATA_DIR=/data
+ENV INSIGHT_MODEL__ENABLE_ROCM=true
+
+# ROCm settings
+ENV HSA_OVERRIDE_GFX_VERSION=11.0.0
+
+# Expose the default port
+EXPOSE 8096
+
+# Set volume for persistent data
+VOLUME ["/data"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD curl -f http://localhost:8096/health || exit 1
+
+# Run the sidecar
+ENTRYPOINT ["insight-sidecar"]


### PR DESCRIPTION
- Add CI workflow for lint, test, and build verification
- Add release workflow to build binaries for Linux/Windows/macOS
- Add Docker workflow for multi-arch container images
- Add Dockerfiles for CPU, CUDA, ROCm, and OpenVINO variants
- Update cargo config with cross-compilation settings

Release binaries support:
- Linux x86_64/aarch64 (cpu, cuda, rocm, openvino)
- Windows x86_64 (cpu, cuda, directml, openvino)
- macOS x86_64/aarch64 (cpu, coreml)

Docker images pushed to ghcr.io:
- latest/cpu (multi-arch: amd64, arm64)
- cuda (CUDA 12.6)
- rocm (ROCm 6.2)
- openvino (OpenVINO 2024.5)